### PR TITLE
Fixed bug of missing events in handhseet; Fixed line bug

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/SplashThread.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/SplashThread.java
@@ -1096,29 +1096,15 @@ public class SplashThread implements Runnable {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                try (InputStream is4 = this.getClass().getClassLoader().getResourceAsStream("reports/reviews.jrxml");
-                        FileOutputStream os4 = new FileOutputStream(settings.getLocalReportsDirectory() + "reviews.jasper");
-                        InputStream is6 = this.getClass().getClassLoader().getResourceAsStream("reports/reviews_detail.jrxml");
-                        FileOutputStream os6 = new FileOutputStream(settings.getLocalReportsDirectory() + "reviews_detail.jasper");
-                        InputStream is5 = this.getClass().getClassLoader().getResourceAsStream("reports/archivefile.jrxml");
-                        FileOutputStream os5 = new FileOutputStream(settings.getLocalReportsDirectory() + "archivefile.jasper");
-                        InputStream is7 = this.getClass().getClassLoader().getResourceAsStream("reports/archivefile_address_detail.jrxml");
-                        FileOutputStream os7 = new FileOutputStream(settings.getLocalReportsDirectory() + "archivefile_address_detail.jasper");
-                        InputStream is8 = this.getClass().getClassLoader().getResourceAsStream("reports/archivefile_review_detail.jrxml");
-                        FileOutputStream os8 = new FileOutputStream(settings.getLocalReportsDirectory() + "archivefile_review_detail.jasper");
-                        InputStream is9 = this.getClass().getClassLoader().getResourceAsStream("reports/archivefile_cost_detail.jrxml");
-                        FileOutputStream os9 = new FileOutputStream(settings.getLocalReportsDirectory() + "archivefile_cost_detail.jasper");) {
-
-                    JasperCompileManager.compileReportToStream(is4, os4);
-                    JasperCompileManager.compileReportToStream(is5, os5);
-                    JasperCompileManager.compileReportToStream(is6, os6);
-                    JasperCompileManager.compileReportToStream(is7, os7);
-                    JasperCompileManager.compileReportToStream(is8, os8);
-                    JasperCompileManager.compileReportToStream(is9, os9);
-                } catch (Throwable t) {
-                    ThreadUtils.showErrorDialog(owner, "Fehler beim Generieren der Druckvorlagen", com.jdimension.jlawyer.client.utils.DesktopUtils.POPUP_TITLE_ERROR);
-                    log.error("Error compiling reports", t);
-
+                List<String> reportList = List.of("reviews", "reviews_detail", "archivefile", "archivefile_address_detail", "archivefile_review_detail", "archivefile_review_event_detail", "archivefile_cost_detail");
+                for (String report : reportList) {
+                    try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("reports/" + report + ".jrxml")) {
+                        FileOutputStream os = new FileOutputStream(settings.getLocalReportsDirectory() + report + ".jasper");
+                        JasperCompileManager.compileReportToStream(is, os);
+                    } catch (Throwable t) {
+                        ThreadUtils.showErrorDialog(owner, "Fehler beim Generieren der Druckvorlagen", com.jdimension.jlawyer.client.utils.DesktopUtils.POPUP_TITLE_ERROR);
+                        log.error("Error compiling reports", t);
+                    }
                 }
             }
 

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/print/PrintStubGenerator.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/print/PrintStubGenerator.java
@@ -726,9 +726,6 @@ public class PrintStubGenerator {
         if (file.getArchiveFileReviewsBeanList() != null) {
             for (int i = 0; i < file.getArchiveFileReviewsBeanList().size(); i++) {
                 ArchiveFileReviewsBean rev = file.getArchiveFileReviewsBeanList().get(i);
-                // events are very dynamic anyways, might not need to be printed
-                if(rev.hasEndDateAndTime())
-                    continue;
                 ReviewsDetail rdet = getReviewDetail(rev, file);
                 s.getReviews().add(rdet);
             }

--- a/j-lawyer-client/src/reports/archivefile.jrxml
+++ b/j-lawyer-client/src/reports/archivefile.jrxml
@@ -245,15 +245,19 @@
                         
                         
                         <subreport>
-				<reportElement positionType="Float" x="10" y="246" width="515" height="1"/>
+				<reportElement positionType="Float" x="10" y="246" width="253" height="1"/>
 				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>
 				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
                                 <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
                                 <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_detail.jasper"]]></subreportExpression>
 			</subreport>
-                        <line>
-				<reportElement positionType="Float" x="263" y="247" width="1" height="200"/>
-			</line>
+                        <subreport>
+				<reportElement positionType="Float" x="273" y="246" width="253" height="1"/>
+				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>
+				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
+                                <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
+                                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_event_detail.jasper"]]></subreportExpression>
+			</subreport>
 		</band>
                 
                 <!-- band height="200" splitType="Stretch">

--- a/j-lawyer-client/src/reports/archivefile_review_event_detail.jrxml
+++ b/j-lawyer-client/src/reports/archivefile_review_event_detail.jrxml
@@ -9,7 +9,7 @@
     <field name="doneStatus" class="java.lang.String"/>
     <field name="fileNumber" class="java.lang.String"/>
     <field name="fileName" class="java.lang.String"/>
-    <filterExpression><![CDATA[!$F{reviewTypeName}.equals("Termin")]]></filterExpression>
+    <filterExpression><![CDATA[$F{reviewTypeName}.equals("Termin")]]></filterExpression>
     <background>
         <band splitType="Stretch"/>
     </background>
@@ -41,10 +41,6 @@
     </title>
     <pageHeader>
         <band height="12" splitType="Stretch">
-                    
-            <line>
-                <reportElement x="253" y="0" width="1" height="12"/>
-            </line>
         </band>
                 
     </pageHeader>
@@ -52,11 +48,7 @@
         <!-- band height="12" splitType="Stretch"/ -->
     </columnHeader>
     <detail>
-        <band height="15" splitType="Stretch">
-            <line>
-                <reportElement x="253" y="0" width="1" height="15"/>
-            </line>
-                        
+        <band height="15" splitType="Stretch">                        
             <textField>
                 <reportElement x="0" y="0" width="70" height="15"/>
                 <textElement>


### PR DESCRIPTION
Fixes #1544
Fixes #1366

Optimized io parsing/compiling for templates (SplashThread)

Refactored Jasper Templates to correctly show middle line (only if there is a "Wiedervorlage"/"Frist"-Item).
Event("Termin") Entries do not have a left-border line, as a divider line is only required if there are two entries on one line.

Removed "skip events" from PrintStubGenerator which skipped events from being shown in the final print. (Maybe needs evaluation if required on the print or not? -> Maybe make optional later on)

Screenshots:
![image](https://user-images.githubusercontent.com/11789478/151218824-6d783124-0b13-4f8c-93b9-2031bd55e48b.png)
![image](https://user-images.githubusercontent.com/11789478/151218794-f18a533b-014c-4d0f-bf8e-a463be550034.png)
![image](https://user-images.githubusercontent.com/11789478/151218737-4db52d90-f711-47b8-85aa-4a1ba79d243c.png)
![image](https://user-images.githubusercontent.com/11789478/151218878-f683f87e-7abb-4948-b7dd-f4800edca491.png)




