### PR TITLE
Fixed vertical line, optimized jasper

### DIFF
--- a/j-lawyer-client/src/reports/archivefile.jrxml
+++ b/j-lawyer-client/src/reports/archivefile.jrxml
@@ -16,7 +16,7 @@
     <variable name="year" class="java.lang.String">
         <variableExpression><![CDATA[new SimpleDateFormat("yyyy").format(new Date())]]></variableExpression>
     </variable>
-    <background>
+    <background >
         <band splitType="Stretch"/>
     </background>
     <title>
@@ -28,8 +28,8 @@
         <band height="21" splitType="Stretch"/>
     </columnHeader>
     <detail>
-        <band height="620" splitType="Stretch">
-			
+        <band height="660" splitType="Stretch">
+	
             <textField>
                 <reportElement x="10" y="20" width="500" height="20"/>
                 <textElement>
@@ -175,12 +175,9 @@
                 <reportElement positionType="Float" x="273" y="246" width="253" height="1"/>
                 <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>               
                 <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_event_detail.jasper"]]></subreportExpression>
-            </subreport>
+            </subreport>  
         </band>               
-        <band height="51">                  
-            <break>
-                <reportElement x="10" y="0" width="515" height="1"/>
-            </break>                         
+        <band height="51">                                
             <textField>
                 <reportElement positionType="Float" x="10" y="10" width="330" height="20"/>
                 <textElement>
@@ -210,7 +207,4 @@
             </textField>
         </band>
     </pageFooter>
-    <summary>
-        <band height="14" splitType="Stretch"/>
-    </summary>
 </jasperReport>

--- a/j-lawyer-client/src/reports/archivefile.jrxml
+++ b/j-lawyer-client/src/reports/archivefile.jrxml
@@ -1,353 +1,216 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="demo" language="groovy" pageWidth="595" pageHeight="842" columnWidth="525" leftMargin="40" rightMargin="30" topMargin="40" bottomMargin="30">
-	<property name="ireport.zoom" value="1.0"/>
-	<property name="ireport.x" value="0"/>
-	<property name="ireport.y" value="0"/>
-	<!-- parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["C:\\MyData\\netbeansws\\ReportDemo\\src\\com\\visural\\report\\"]]></defaultValueExpression>
-	</parameter -->
-        <parameter name="SubReportDir" class="java.lang.String" isForPrompting="false"/>
+    <property name="ireport.zoom" value="1.0"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <parameter name="SubReportDir" class="java.lang.String" isForPrompting="false"/>
 
-        <field name="fileNumber" class="java.lang.String"/>
-	<field name="parties" class="java.util.List"/>
-        <field name="reviews" class="java.util.List"/>
-        <field name="name" class="java.lang.String"/>
-	<field name="notice" class="java.lang.String"/>
-        <field name="printDate" class="java.lang.String"/>
-	<!-- field name="dictateSign" class="java.lang.String"/ -->
-        <field name="reason" class="java.lang.String"/>
-        <field name="lawyer" class="java.lang.String"/>
-        <!-- field name="claimNumber" class="java.lang.String"/>
-        <field name="claimValue" class="java.lang.String"/ -->
-        <background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<!-- band height="35" splitType="Stretch">
-			<staticText>
-				<reportElement x="0" y="0" width="204" height="34"/>
-				<textElement>
-					<font size="26" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Contact Report]]></text>
-			</staticText>
-		</band -->
-	</title>
-	<pageHeader>
-		<band height="17" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="21" splitType="Stretch"/>
-	</columnHeader>
-	<detail>
-		<band height="540" splitType="Stretch">
+    <field name="fileNumber" class="java.lang.String"/>
+    <field name="parties" class="java.util.List"/>
+    <field name="reviews" class="java.util.List"/>
+    <field name="name" class="java.lang.String"/>
+    <field name="notice" class="java.lang.String"/>
+    <field name="printDate" class="java.lang.String"/>
+    <field name="reason" class="java.lang.String"/>
+    <field name="lawyer" class="java.lang.String"/>
+    <variable name="year" class="java.lang.String">
+        <variableExpression><![CDATA[new SimpleDateFormat("yyyy").format(new Date())]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <title>
+    </title>
+    <pageHeader>
+        <band height="17" splitType="Stretch"/>
+    </pageHeader>
+    <columnHeader>
+        <band height="21" splitType="Stretch"/>
+    </columnHeader>
+    <detail>
+        <band height="620" splitType="Stretch">
 			
-			<textField>
-				<reportElement x="10" y="20" width="500" height="20"/>
-				<textElement>
-					<font size="14" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber} + " - Aktendaten vom " + $F{printDate}]]></textFieldExpression>
-			</textField>
-			<!-- textField>
-				<reportElement x="104" y="0" width="277" height="20"/>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{firstName}]]></textFieldExpression>
-			</textField -->
-			<!-- textField>
-				<reportElement x="104" y="20" width="277" height="20"/>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{lastName}]]></textFieldExpression>
-			</textField -->
-			
-                        <line>
-				<reportElement x="10" y="50" width="515" height="1"/>
-			</line>
+            <textField>
+                <reportElement x="10" y="20" width="500" height="20"/>
+                <textElement>
+                    <font size="14" isBold="true"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber} + " - Aktendaten vom " + $F{printDate}]]></textFieldExpression>
+            </textField>
+		
+            <line>
+                <reportElement x="10" y="50" width="515" height="1"/>
+            </line>
                         
-                        <textField>
-				<reportElement x="10" y="60" width="490" height="20"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber}]]></textFieldExpression>
-			</textField>
+            <textField>
+                <reportElement x="10" y="60" width="490" height="20"/>
+                <textElement>
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber}]]></textFieldExpression>
+            </textField>
                         
-                        <staticText>
-				<reportElement x="10" y="80" width="130" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Kurzrubrum:]]></text>
-			</staticText>
-                        <textField isStretchWithOverflow="true">
-				<reportElement x="110" y="80" width="430" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{name}]]></textFieldExpression>
-			</textField>
+            <staticText>
+                <reportElement x="10" y="80" width="130" height="20"/>
+                <textElement>
+                    <font size="10" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Kurzrubrum:]]></text>
+            </staticText>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="110" y="80" width="430" height="20"/>
+                <textElement>
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{name}]]></textFieldExpression>
+            </textField>
                         
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="100" width="110" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[wegen:]]></text>
-			</staticText>
-                        <textField isStretchWithOverflow="true">
-				<reportElement positionType="Float" x="110" y="100" width="430" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{reason}]]></textFieldExpression>
-			</textField>
+            <staticText>
+                <reportElement positionType="Float" x="10" y="100" width="110" height="20"/>
+                <textElement>
+                    <font size="10" isBold="true"/>
+                </textElement>
+                <text><![CDATA[wegen:]]></text>
+            </staticText>
+            <textField isStretchWithOverflow="true">
+                <reportElement positionType="Float" x="110" y="100" width="430" height="20"/>
+                <textElement>
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{reason}]]></textFieldExpression>
+            </textField>
                         
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="120" width="130" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Anwalt:]]></text>
-			</staticText>
-                        <textField>
-				<reportElement positionType="Float" x="110" y="120" width="430" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{lawyer}]]></textFieldExpression>
-			</textField>
+            <staticText>
+                <reportElement positionType="Float" x="10" y="120" width="130" height="20"/>
+                <textElement>
+                    <font size="10" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Anwalt:]]></text>
+            </staticText>
+            <textField>
+                <reportElement positionType="Float" x="110" y="120" width="430" height="20"/>
+                <textElement>
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{lawyer}]]></textFieldExpression>
+            </textField>
                         
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="140" width="130" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Notiz:]]></text>
-			</staticText>
-                        <textField isStretchWithOverflow="true">
-				<reportElement positionType="Float" x="110" y="140" width="370" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{notice}]]></textFieldExpression>
-			</textField>
+            <staticText>
+                <reportElement positionType="Float" x="10" y="140" width="130" height="20"/>
+                <textElement>
+                    <font size="10" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Notiz:]]></text>
+            </staticText>
+            <textField isStretchWithOverflow="true">
+                <reportElement positionType="Float" x="110" y="140" width="370" height="20"/>
+                <textElement>
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA[$F{notice}]]></textFieldExpression>
+            </textField>
                         
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="160" width="290" height="5"/>
-				<textElement>
-					<font size="5" isBold="true"/>
-				</textElement>
-				<text><![CDATA[   ]]></text>
-			</staticText>
+            <staticText>
+                <reportElement positionType="Float" x="10" y="160" width="290" height="5"/>
+                <textElement>
+                    <font size="5" isBold="true"/>
+                </textElement>
+                <text><![CDATA[   ]]></text>
+            </staticText>
+       
+            <line>
+                <reportElement positionType="Float" x="10" y="165" width="515" height="1"/>
+            </line>
                         
-                        <!-- staticText>
-				<reportElement x="0" y="120" width="140" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Schadennummer:]]></text>
-			</staticText>
-                        <textField>
-				<reportElement x="150" y="120" width="440" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{claimNumber}]]></textFieldExpression>
-			</textField>
+            <staticText>
+                <reportElement positionType="Float" x="10" y="175" width="330" height="20"/>
+                <textElement>
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Beteiligte:]]></text>
+            </staticText>
                         
-                        <staticText>
-				<reportElement x="0" y="140" width="140" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Gegenstandswert:]]></text>
-			</staticText>
-                        <textField>
-				<reportElement x="150" y="140" width="440" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{claimValue}]]></textFieldExpression>
-			</textField -->
+            <subreport>
+                <reportElement positionType="Float" x="14" y="200" width="515" height="15"/>
+                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{parties})]]></dataSourceExpression>                
+                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_address_detail.jasper"]]></subreportExpression>
+            </subreport>
+                       
+            <!-- Section for "Wiedervoralgen/Fristen" and "Termine" -->                      
+            <line>
+                <reportElement positionType="Float" x="10" y="215" width="515" height="1"/>
+            </line>
+                                                                                                         
+            <staticText>
+                <reportElement positionType="Float" x="10" y="229" width="390" height="17"/>
+                <textElement>
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Wiedervorlagen/Fristen]]></text>
+            </staticText>
                         
-                        <!-- staticText>
-				<reportElement x="0" y="160" width="140" height="20"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Diktatzeichen:]]></text>
-			</staticText>
-                        <textField>
-				<reportElement x="150" y="160" width="440" height="20"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{dictateSign}]]></textFieldExpression>
-			</textField -->
-                        
-                        <line>
-				<reportElement positionType="Float" x="10" y="165" width="515" height="1"/>
-			</line>
-                        
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="175" width="330" height="20"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Beteiligte:]]></text>
-			</staticText>
-                        
-                        <subreport>
-				<reportElement positionType="Float" x="14" y="200" width="515" height="15"/>
-				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{parties})]]></dataSourceExpression>
-				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_address_detail.jasper"]]></subreportExpression>
-			</subreport>
-                        
-                        
-                        <line>
-				<reportElement positionType="Float" x="10" y="215" width="515" height="1"/>
-			</line>
-                        
-                        
-                        
-                        
-                        <staticText>
-				<reportElement positionType="Float" x="10" y="229" width="390" height="17"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Wiedervorlagen/Fristen]]></text>
-			</staticText>
-                        
-                        <staticText>
-				<reportElement positionType="Float" x="283" y="229" width="80" height="17"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Termine]]></text>
-			</staticText>
-                        
-                        <line>
-				<reportElement positionType="Float" x="10" y="245" width="515" height="1"/>
-			</line>
-                        <!-- line>
-				<reportElement positionType="Float" x="263" y="365" width="1" height="20"/>
-			</line -->
-                        
-                        
-                        
-                        
-                        
-                        <subreport>
-				<reportElement positionType="Float" x="10" y="246" width="253" height="1"/>
-				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>
-				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_detail.jasper"]]></subreportExpression>
-			</subreport>
-                        <subreport>
-				<reportElement positionType="Float" x="273" y="246" width="253" height="1"/>
-				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>
-				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_event_detail.jasper"]]></subreportExpression>
-			</subreport>
-		</band>
-                
-                <!-- band height="200" splitType="Stretch">
-                    <line>
-				<reportElement x="263" y="0" width="1" height="200"/>
-			</line>
-                <staticText>
-				<reportElement positionType="Float" x="0" y="10" width="340" height="20"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Termine   ]]></text>
-			</staticText>
-                        
-                        </band -->
-                
-                <!-- band height="200" splitType="Stretch">
-                <staticText>
-				<reportElement positionType="Float" x="0" y="0" width="340" height="200"/>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[   ]]></text>
-			</staticText>
-                        </band -->
-                
-		<band height="51">
-                    
+            <staticText>
+                <reportElement positionType="Float" x="283" y="229" width="80" height="17"/>
+                <textElement>
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Termine]]></text>
+            </staticText>
+                               
+            <!-- Underline for header -->
+            <line>
+                <reportElement positionType="Float" x="10" y="245" width="515" height="1"/>
+            </line>
+
+            <!-- Vertical line between "Wiedervorlagen/Fristen" and "Termine" -->     
+            <line>
+                <reportElement positionType="Float" x="263" y="246" width="1" height="374"/>
+            </line>
+            <subreport>
+                <reportElement positionType="Float" x="10" y="246" width="243" height="1"/>
+                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>                
+                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_detail.jasper"]]></subreportExpression>
+            </subreport>
+            <subreport>
+                <reportElement positionType="Float" x="273" y="246" width="253" height="1"/>
+                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.data.JRBeanCollectionDataSource($F{reviews})]]></dataSourceExpression>               
+                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_review_event_detail.jasper"]]></subreportExpression>
+            </subreport>
+        </band>               
+        <band height="51">                  
             <break>
                 <reportElement x="10" y="0" width="515" height="1"/>
-            </break> 
-
-            <!-- break type="Page">
-                <reportElement
-                    x="0"
-                    y="17"
-                    width="784"
-                    height="1"
-                    key="element-1"/>
-            </break -->
-                        <!-- group name="record" isStartNewPage="true">
-    <groupExpression><![CDATA[$V{REPORT_COUNT}]]></groupExpression>
-</group -->
-
-
-			<!-- line>
-				<reportElement x="0" y="1" width="525" height="1"/>
-			</line -->
+            </break>                         
+            <textField>
+                <reportElement positionType="Float" x="10" y="10" width="330" height="20"/>
+                <textElement>
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <textFieldExpression class="java.lang.String"><![CDATA["Kostenvorblatt für Akte " + $F{fileNumber}]]></textFieldExpression>
+            </textField>
                         
-                        <!-- staticText>
-				<reportElement positionType="Float" x="0" y="10" width="340" height="20"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Kostenvorblatt:]]></text>
-			</staticText -->
-                        
-                        <textField>
-				<reportElement positionType="Float" x="10" y="10" width="330" height="20"/>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Kostenvorblatt für Akte " + $F{fileNumber}]]></textFieldExpression>
-			</textField>
-                        
-                        <subreport>
-				<reportElement positionType="Float" x="10" y="10" width="515" height="20"/>
-				<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(1)]]></dataSourceExpression>
-				<!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <!-- subreportExpression class="java.lang.String"><![CDATA[$P{SUBREPORT_DIR} + "demo_address.jasper"]]></subreportExpression -->
-                                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_cost_detail.jasper"]]></subreportExpression>
-			</subreport>
-		</band>
-	</detail>
-	<columnFooter>
-		<band height="19" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<!-- band height="18" splitType="Stretch"/ -->
-                <band height="35" splitType="Stretch">
-			<staticText>
-				<reportElement x="10" y="0" width="194" height="34"/>
-				<textElement>
-					<font size="8" isBold="true"/>
-				</textElement>
-				<text><![CDATA[j-lawyer.org 2012-2021]]></text>
-			</staticText>
-		</band>
-	</pageFooter>
-	<summary>
-		<band height="14" splitType="Stretch"/>
-	</summary>
+            <subreport>
+                <reportElement positionType="Float" x="0" y="10" width="515" height="20"/>
+                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(1)]]></dataSourceExpression>                
+                <subreportExpression class="java.lang.String"><![CDATA[$P{SubReportDir} + "archivefile_cost_detail.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </detail>
+    <columnFooter>
+        <band height="19" splitType="Stretch"/>
+    </columnFooter>
+    <pageFooter>
+        <band height="35" splitType="Stretch">
+            <textField>
+                <reportElement x="10" y="0" width="194" height="34"/>
+                <textElement>
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA["j-lawyer.org 2012-" + $V{year}]]></textFieldExpression>
+            </textField>
+        </band>
+    </pageFooter>
+    <summary>
+        <band height="14" splitType="Stretch"/>
+    </summary>
 </jasperReport>

--- a/j-lawyer-client/src/reports/archivefile_cost_detail.jrxml
+++ b/j-lawyer-client/src/reports/archivefile_cost_detail.jrxml
@@ -1,200 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report2" language="groovy" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
-	<property name="ireport.zoom" value="1.0"/>
-	<property name="ireport.x" value="0"/>
-	<property name="ireport.y" value="0"/>
-	<style name="table">
-		<box>
-			<pen lineWidth="1.0" lineColor="#000000"/>
-		</box>
-	</style>
-	<style name="table_TH" mode="Opaque" backcolor="#F0F8FF">
-		<box>
-			<pen lineWidth="0.5" lineColor="#000000"/>
-		</box>
-	</style>
-	<style name="table_CH" mode="Opaque" backcolor="#BFE1FF">
-		<box>
-			<pen lineWidth="0.5" lineColor="#000000"/>
-		</box>
-	</style>
-	<style name="table_TD" mode="Opaque" backcolor="#FFFFFF">
-		<box>
-			<pen lineWidth="0.5" lineColor="#000000"/>
-		</box>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style backcolor="#EFF7FF"/>
-		</conditionalStyle>
-	</style>
-	<subDataset name="Table Dataset 1"/>
-	<subDataset name="Table Dataset 2"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<detail>
-		<band height="125" splitType="Stretch">
-			<componentElement>
-				<reportElement key="table" style="table" x="0" y="0" width="555" height="125"/>
-				<jr:table xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
-					<datasetRun subDataset="Table Dataset 2">
-						<dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(19)]]></dataSourceExpression>
-					</datasetRun>
-					<jr:column width="49">
-						<jr:columnHeader style="table_CH" height="35" rowSpan="2">
-							<staticText>
-								<reportElement x="0" y="0" width="49" height="30"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[Datum]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-					</jr:column>
-					<jr:column width="106">
-						<jr:columnHeader style="table_CH" height="35" rowSpan="2">
-							<staticText>
-								<reportElement x="0" y="0" width="106" height="30"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[Zahlung von / an]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-					</jr:column>
-					<jr:column width="55">
-						<jr:columnHeader style="table_CH" height="35" rowSpan="2">
-							<staticText>
-								<reportElement x="0" y="0" width="55" height="30"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[Gesamt- betrag]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-					</jr:column>
-					<jr:columnGroup width="100">
-						<jr:columnHeader style="table_CH" height="18" rowSpan="1">
-							<staticText>
-								<reportElement x="0" y="0" width="100" height="18"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[Gebühren]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Einn.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Ausg.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-					</jr:columnGroup>
-					<jr:columnGroup width="100">
-						<jr:columnHeader style="table_CH" height="18" rowSpan="1">
-							<staticText>
-								<reportElement x="0" y="0" width="100" height="18"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[fremdes Geld]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Einn.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Ausg.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-					</jr:columnGroup>
-					<jr:columnGroup width="100">
-						<jr:columnHeader style="table_CH" height="18" rowSpan="1">
-							<staticText>
-								<reportElement x="0" y="0" width="100" height="18"/>
-								<textElement>
-									<font isBold="true"/>
-									<paragraph leftIndent="3" spacingBefore="3"/>
-								</textElement>
-								<text><![CDATA[Auslagen]]></text>
-							</staticText>
-						</jr:columnHeader>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Einn.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-						<jr:column width="50">
-							<jr:columnHeader style="table_CH" height="17" rowSpan="1">
-								<staticText>
-									<reportElement x="0" y="0" width="50" height="17"/>
-									<textElement>
-										<font isBold="true"/>
-										<paragraph leftIndent="3" spacingBefore="3"/>
-									</textElement>
-									<text><![CDATA[Ausg.]]></text>
-								</staticText>
-							</jr:columnHeader>
-							<jr:detailCell style="table_TD" height="30" rowSpan="1"/>
-						</jr:column>
-					</jr:columnGroup>
-				</jr:table>
-			</componentElement>
-		</band>
-	</detail>
+    <property name="ireport.zoom" value="1.0"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <style name="table">
+        <box>
+            <pen lineWidth="1.0" lineColor="#000000"/>
+        </box>
+    </style>
+    <style name="table_TH" mode="Opaque" backcolor="#F0F8FF">
+        <box>
+            <pen lineWidth="0.5" lineColor="#000000"/>
+        </box>
+    </style>
+    <style name="table_CH" mode="Opaque" backcolor="#BFE1FF">
+        <box>
+            <pen lineWidth="0.5" lineColor="#000000"/>
+        </box>
+    </style>
+    <style name="table_TD" mode="Opaque" backcolor="#FFFFFF">
+        <box>
+            <pen lineWidth="0.5" lineColor="#000000"/>
+        </box>
+        <conditionalStyle>
+            <conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
+            <style backcolor="#EFF7FF"/>
+        </conditionalStyle>
+    </style>
+    <subDataset name="Table Dataset 1"/>
+    <subDataset name="Table Dataset 2"/>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <detail>
+        <band height="125" splitType="Stretch">
+            <componentElement>
+                <reportElement key="table" style="table" x="0" y="0" width="555" height="125"/>
+                <jr:table xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
+                    <datasetRun subDataset="Table Dataset 2">
+                        <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(19)]]></dataSourceExpression>
+                    </datasetRun>
+                    <jr:column width="49">
+                        <jr:columnHeader style="table_CH" height="35" rowSpan="2">
+                            <staticText>
+                                <reportElement x="0" y="0" width="49" height="30"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[Datum]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                    </jr:column>
+                    <jr:column width="106">
+                        <jr:columnHeader style="table_CH" height="35" rowSpan="2">
+                            <staticText>
+                                <reportElement x="0" y="0" width="106" height="30"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[Zahlung von / an]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                    </jr:column>
+                    <jr:column width="55">
+                        <jr:columnHeader style="table_CH" height="35" rowSpan="2">
+                            <staticText>
+                                <reportElement x="0" y="0" width="55" height="30"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[Gesamt- betrag]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                    </jr:column>
+                    <jr:columnGroup width="100">
+                        <jr:columnHeader style="table_CH" height="18" rowSpan="1">
+                            <staticText>
+                                <reportElement x="0" y="0" width="100" height="18"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[Gebühren]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Einn.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Ausg.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                    </jr:columnGroup>
+                    <jr:columnGroup width="100">
+                        <jr:columnHeader style="table_CH" height="18" rowSpan="1">
+                            <staticText>
+                                <reportElement x="0" y="0" width="100" height="18"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[fremdes Geld]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Einn.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Ausg.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                    </jr:columnGroup>
+                    <jr:columnGroup width="100">
+                        <jr:columnHeader style="table_CH" height="18" rowSpan="1">
+                            <staticText>
+                                <reportElement x="0" y="0" width="100" height="18"/>
+                                <textElement>
+                                    <font isBold="true"/>
+                                    <paragraph leftIndent="3" spacingBefore="3"/>
+                                </textElement>
+                                <text><![CDATA[Auslagen]]></text>
+                            </staticText>
+                        </jr:columnHeader>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Einn.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                        <jr:column width="50">
+                            <jr:columnHeader style="table_CH" height="17" rowSpan="1">
+                                <staticText>
+                                    <reportElement x="0" y="0" width="50" height="17"/>
+                                    <textElement>
+                                        <font isBold="true"/>
+                                        <paragraph leftIndent="3" spacingBefore="3"/>
+                                    </textElement>
+                                    <text><![CDATA[Ausg.]]></text>
+                                </staticText>
+                            </jr:columnHeader>
+                            <jr:detailCell style="table_TD" height="30" rowSpan="1"/>
+                        </jr:column>
+                    </jr:columnGroup>
+                </jr:table>
+            </componentElement>
+        </band>
+    </detail>
 </jasperReport>

--- a/j-lawyer-client/src/reports/archivefile_review_detail.jrxml
+++ b/j-lawyer-client/src/reports/archivefile_review_detail.jrxml
@@ -10,53 +10,11 @@
     <field name="fileNumber" class="java.lang.String"/>
     <field name="fileName" class="java.lang.String"/>
     <filterExpression><![CDATA[!$F{reviewTypeName}.equals("Termin")]]></filterExpression>
-    <background>
-        <band splitType="Stretch"/>
-    </background>
-    <title>
-        <!-- band height="20" splitType="Stretch">
-                <staticText>
-                        <reportElement x="0" y="3" width="400" height="17"/>
-                        <textElement>
-                                <font size="12" isBold="true"/>
-                        </textElement>
-                        <text><![CDATA[Wiedervorlagen/Fristen]]></text>
-                </staticText>
-                
-                <staticText>
-                        <reportElement x="273" y="3" width="80" height="17"/>
-                        <textElement>
-                                <font size="12" isBold="true"/>
-                        </textElement>
-                        <text><![CDATA[Termine]]></text>
-                </staticText>
-                
-                <line>
-                        <reportElement x="0" y="19" width="525" height="1"/>
-                </line>
-                <line>
-                        <reportElement x="263" y="0" width="1" height="20"/>
-                </line>
-        </band -->
-    </title>
     <pageHeader>
-        <band height="12" splitType="Stretch">
-                    
-            <line>
-                <reportElement x="253" y="0" width="1" height="12"/>
-            </line>
-        </band>
-                
+        <band height="12" splitType="Stretch" />                
     </pageHeader>
-    <columnHeader>
-        <!-- band height="12" splitType="Stretch"/ -->
-    </columnHeader>
     <detail>
-        <band height="15" splitType="Stretch">
-            <line>
-                <reportElement x="253" y="0" width="1" height="15"/>
-            </line>
-                        
+        <band height="15" splitType="Stretch">                        
             <textField>
                 <reportElement x="0" y="0" width="70" height="15"/>
                 <textElement>
@@ -64,54 +22,13 @@
                 </textElement>
                 <textFieldExpression class="java.util.Date"><![CDATA[$F{reviewDate}]]></textFieldExpression>
             </textField>
-            <!-- textField isStretchWithOverflow="true">
-                    <reportElement x="80" y="0" width="120" height="17"/>
-                    <textElement>
-                            <font size="10"/>
-                    </textElement>
-                    <textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber}]]></textFieldExpression>
-            </textField>
             <textField isStretchWithOverflow="true">
-                    <reportElement x="200" y="0" width="120" height="17"/>
-                    <textElement>
-                            <font size="10"/>
-                    </textElement>
-                    <textFieldExpression class="java.lang.String"><![CDATA[$F{fileName}]]></textFieldExpression>
-            </textField -->
-            <textField isStretchWithOverflow="true">
-                <reportElement x="70" y="0" width="190" height="15"/>
+                <reportElement x="70" y="0" width="165" height="15"/>
                 <textElement>
                     <font size="10"/>
                 </textElement>
                 <textFieldExpression class="java.lang.String"><![CDATA[$F{reviewReason} +" (" + $F{reviewTypeName} +")"]]></textFieldExpression>                                
-            </textField>
-                        <!-- textField isStretchWithOverflow="true">
-				<reportElement x="400" y="0" width="120" height="17"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{doneStatus}]]></textFieldExpression>
-			</textField -->
-                        
-                        
-                      
+            </textField>    
         </band>
     </detail>
-    <columnFooter>
-        <!-- band height="20" splitType="Stretch"/ -->
-    </columnFooter>
-    <pageFooter>
-        <!-- band height="30" splitType="Stretch">
-<staticText>
-                <reportElement positionType="Float" x="0" y="10" width="340" height="20"/>
-                <textElement>
-                        <font size="12" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Termine   ]]></text>
-        </staticText>
-        </band -->
-    </pageFooter>
-    <summary>
-        <!-- band height="10" splitType="Stretch"/ -->
-    </summary>
 </jasperReport>

--- a/j-lawyer-client/src/reports/archivefile_review_event_detail.jrxml
+++ b/j-lawyer-client/src/reports/archivefile_review_event_detail.jrxml
@@ -10,100 +10,25 @@
     <field name="fileNumber" class="java.lang.String"/>
     <field name="fileName" class="java.lang.String"/>
     <filterExpression><![CDATA[$F{reviewTypeName}.equals("Termin")]]></filterExpression>
-    <background>
-        <band splitType="Stretch"/>
-    </background>
-    <title>
-        <!-- band height="20" splitType="Stretch">
-                <staticText>
-                        <reportElement x="0" y="3" width="400" height="17"/>
-                        <textElement>
-                                <font size="12" isBold="true"/>
-                        </textElement>
-                        <text><![CDATA[Wiedervorlagen/Fristen]]></text>
-                </staticText>
-                
-                <staticText>
-                        <reportElement x="273" y="3" width="80" height="17"/>
-                        <textElement>
-                                <font size="12" isBold="true"/>
-                        </textElement>
-                        <text><![CDATA[Termine]]></text>
-                </staticText>
-                
-                <line>
-                        <reportElement x="0" y="19" width="525" height="1"/>
-                </line>
-                <line>
-                        <reportElement x="263" y="0" width="1" height="20"/>
-                </line>
-        </band -->
-    </title>
     <pageHeader>
-        <band height="12" splitType="Stretch">
-        </band>
-                
+        <band height="12" splitType="Stretch"/>
     </pageHeader>
-    <columnHeader>
-        <!-- band height="12" splitType="Stretch"/ -->
-    </columnHeader>
     <detail>
         <band height="15" splitType="Stretch">                        
             <textField>
-                <reportElement x="0" y="0" width="85" height="15"/>
+                <reportElement x="0" y="0" width="105" height="15"/>
                 <textElement>
                     <font size="10" isBold="true"/>
                 </textElement>
                 <textFieldExpression class="java.util.Date"><![CDATA[$F{reviewDate}]]></textFieldExpression>
             </textField>
-            <!-- textField isStretchWithOverflow="true">
-                    <reportElement x="80" y="0" width="120" height="17"/>
-                    <textElement>
-                            <font size="10"/>
-                    </textElement>
-                    <textFieldExpression class="java.lang.String"><![CDATA[$F{fileNumber}]]></textFieldExpression>
-            </textField>
             <textField isStretchWithOverflow="true">
-                    <reportElement x="200" y="0" width="120" height="17"/>
-                    <textElement>
-                            <font size="10"/>
-                    </textElement>
-                    <textFieldExpression class="java.lang.String"><![CDATA[$F{fileName}]]></textFieldExpression>
-            </textField -->
-            <textField isStretchWithOverflow="true">
-                <reportElement x="85" y="0" width="175" height="15"/>
+                <reportElement x="105" y="0" width="145" height="15"/>
                 <textElement>
                     <font size="10"/>
                 </textElement>
                 <textFieldExpression class="java.lang.String"><![CDATA[$F{reviewReason} +" (" + $F{reviewTypeName} +")"]]></textFieldExpression>                                
-            </textField>
-                        <!-- textField isStretchWithOverflow="true">
-				<reportElement x="400" y="0" width="120" height="17"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{doneStatus}]]></textFieldExpression>
-			</textField -->
-                        
-                        
-                      
+            </textField>   
         </band>
     </detail>
-    <columnFooter>
-        <!-- band height="20" splitType="Stretch"/ -->
-    </columnFooter>
-    <pageFooter>
-        <!-- band height="30" splitType="Stretch">
-<staticText>
-                <reportElement positionType="Float" x="0" y="10" width="340" height="20"/>
-                <textElement>
-                        <font size="12" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Termine   ]]></text>
-        </staticText>
-        </band -->
-    </pageFooter>
-    <summary>
-        <!-- band height="10" splitType="Stretch"/ -->
-    </summary>
 </jasperReport>


### PR DESCRIPTION
So I optimized some jasper files by removing commented code (is tracked by git either way) and tried to optimize the vertical line.
One problem which I discovered is, that after 3+ events jasper automatically adds another empty page.
Maybe you @j-dimension have an idea? Else I guess that's the best we can get so far.

![image](https://user-images.githubusercontent.com/11789478/151411837-0e0d1f0d-dea7-4c25-9ae5-37ba88e2f748.png)

I also optimized the "j-lawyer.org" notice in the bottom by automatically calculating the current year.

Let's discuss if that solution is goog enough before you merge so I can continue to work on that branch :)