### PR TITLE
Removed setting custom start/end date from tooltip method

### DIFF
--- a/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
@@ -238,13 +238,6 @@ public class DayContentPanel extends JPanel {
                 } else {
                     List holidayEvents = EventCollectionRepository.get(calendar).getHolidayEvents(owner.getDate());
                     if (holidayEvents.isEmpty()) {
-                        startDate = CalendarUtil.pixelToDate(
-                                owner.getDate(), e.getY(),
-                                getHeight());
-                        endDate = CalendarUtil.pixelToDate(owner.getDate(),
-                                e.getY(), getHeight());
-                        startDate = CalendarUtil.roundDateToHalfAnHour(startDate, false);
-                        endDate = CalendarUtil.roundDateToHalfAnHour(endDate, true);
                         setToolTipText(sdf.format(startDate) + " - " + sdf.format(endDate));
                     } else {
                         setToolTipText(calendar.getTooltipFormater().format(holidayEvents));


### PR DESCRIPTION
Missed in #1656 this is not required completely and works without