### PR TITLE
Draft: Add Details Pane to InvolvedPartyEntryPanel

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/Main.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/Main.java
@@ -1,4 +1,4 @@
-/*
+    /*
  *                     GNU AFFERO GENERAL PUBLIC LICENSE
  *                        Version 3, 19 November 2007
  *

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.form
@@ -134,7 +134,7 @@
                       <Component id="cmdActions" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Component id="jXTaskPane1" alignment="0" max="32767" attributes="0"/>
-                  <Component id="jXTaskPane2" alignment="0" max="32767" attributes="0"/>
+                  <Component id="detailsContentTaskPane" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -157,7 +157,7 @@
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jXTaskPane2" max="-2" attributes="0"/>
+              <Component id="detailsContentTaskPane" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jXTaskPane1" min="-2" max="-2" attributes="0"/>
               <EmptySpace pref="21" max="32767" attributes="0"/>
@@ -239,7 +239,7 @@
         <Property name="opaque" type="boolean" value="true"/>
       </Properties>
     </Component>
-    <Container class="org.jdesktop.swingx.JXTaskPane" name="jXTaskPane2">
+    <Container class="org.jdesktop.swingx.JXTaskPane" name="detailsContentTaskPane">
       <Properties>
         <Property name="expanded" type="boolean" value="false"/>
         <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.form
@@ -133,7 +133,8 @@
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="cmdActions" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Component id="jXTaskPane1" max="32767" attributes="0"/>
+                  <Component id="jXTaskPane1" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jXTaskPane2" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -142,7 +143,7 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Component id="lblType" max="32767" attributes="0"/>
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="cmdActions" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -156,8 +157,10 @@
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
+              <Component id="jXTaskPane2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="jXTaskPane1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace pref="21" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -170,7 +173,7 @@
         </Property>
         <Property name="text" type="java.lang.String" value="Kutschke, Jens"/>
         <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-          <Color id="Handcursor"/>
+          <Color id="Default Cursor"/>
         </Property>
       </Properties>
       <Events>
@@ -236,13 +239,62 @@
         <Property name="opaque" type="boolean" value="true"/>
       </Properties>
     </Component>
-    <Container class="org.jdesktop.swingx.JXTaskPane" name="jXTaskPane1">
+    <Container class="org.jdesktop.swingx.JXTaskPane" name="jXTaskPane2">
       <Properties>
         <Property name="expanded" type="boolean" value="false"/>
         <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
           <Color blue="ff" green="ff" red="ff" type="rgb"/>
         </Property>
         <Property name="title" type="java.lang.String" value="Details"/>
+        <Property name="animated" type="boolean" value="false"/>
+      </Properties>
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Component id="jScrollPane1" min="-2" max="-2" attributes="0"/>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="jScrollPane1" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+          <Properties>
+            <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+              <Border info="null"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+          </AuxValues>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <SubComponents>
+            <Component class="javax.swing.JTextPane" name="detailsContent">
+              <Properties>
+                <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                  <Border info="null"/>
+                </Property>
+              </Properties>
+            </Component>
+          </SubComponents>
+        </Container>
+      </SubComponents>
+    </Container>
+    <Container class="org.jdesktop.swingx.JXTaskPane" name="jXTaskPane1">
+      <Properties>
+        <Property name="expanded" type="boolean" value="false"/>
+        <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+          <Color blue="ff" green="ff" red="ff" type="rgb"/>
+        </Property>
+        <Property name="title" type="java.lang.String" value="Zus&#xe4;tzliche Angaben"/>
         <Property name="animated" type="boolean" value="false"/>
       </Properties>
 
@@ -272,6 +324,7 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" attributes="0">
+                  <EmptySpace min="-2" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="txtContact" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
@@ -850,7 +850,8 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             StringBuilder address = new StringBuilder();
             // Add street + street number
             if (!this.a.getStreet().isEmpty() && this.a.getStreetNumber().isEmpty()) {
-                address.append(this.a.getStreet()).append("<br>");
+                address.append(this.a.getStreet())
+                        .append("<br>");
             } else if (!this.a.getStreet().isEmpty() && !this.a.getStreetNumber().isEmpty()) {
                 address.append(this.a.getStreet())
                         .append(" ")
@@ -863,7 +864,9 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                         .append("<br>");
             } else if (!this.a.getZipCode().isEmpty() && !this.a.getCity().isEmpty()) {
                 address.append(this.a.getZipCode())
-                        .append(" ").append(this.a.getCity()).append("<br>");
+                        .append(" ")
+                        .append(this.a.getCity())
+                        .append("<br>");
             }
             // Add country
             if (!this.a.getCountry().isEmpty()) {

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
@@ -847,32 +847,37 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             if (!this.a.getWebsite().isEmpty()) {
                 content.append(getContentRow("Website:", this.a.getWebsite()));
             }
-            String address = "";
+            StringBuilder address = new StringBuilder();
             // Add street + street number
             if (!this.a.getStreet().isEmpty() && this.a.getStreetNumber().isEmpty()) {
-                address += this.a.getStreet() + "<br>";
+                address.append(this.a.getStreet()).append("<br>");
             } else if (!this.a.getStreet().isEmpty() && !this.a.getStreetNumber().isEmpty()) {
-                address += this.a.getStreet() + " " + this.a.getStreetNumber() + "<br>";
+                address.append(this.a.getStreet())
+                        .append(" ")
+                        .append(this.a.getStreetNumber())
+                        .append("<br>");
             }
             // Add zipcode + city
             if (!this.a.getZipCode().isEmpty() && this.a.getCity().isEmpty()) {
-                address += this.a.getZipCode() + "<br>";
+                address.append(this.a.getZipCode())
+                        .append("<br>");
             } else if (!this.a.getZipCode().isEmpty() && !this.a.getCity().isEmpty()) {
-                address += this.a.getZipCode() + " " + this.a.getCity() + "<br>";
+                address.append(this.a.getZipCode())
+                        .append(" ").append(this.a.getCity()).append("<br>");
             }
             // Add country
             if (!this.a.getCountry().isEmpty()) {
-                address += this.a.getCountry();
+                address.append(this.a.getCountry());
             }
-            if (!address.isEmpty()) {
-                content.append(getContentRow("Adresse:", address));
+            if (!address.toString().isEmpty()) {
+                content.append(getContentRow("Adresse:", address.toString()));
             }
             wrapper.append(content.toString());
             wrapper.append("</table>");
             wrapper.append("</html>");
             this.detailsContent.setBorder(null);
             this.detailsContent.setContentType("text/html");
-            this.detailsContent.setText(content.toString());
+            this.detailsContent.setText(wrapper.toString());
             if (content.toString().isEmpty()) {
                 detailsContentTaskPane.setVisible(false);
             }
@@ -881,10 +886,16 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
     }
 
     private String getContentRow(String label, String value) {
-        return "<tr>"
-                + "<td><b>" + label + "</b></td>"
-                + "<td>" + value + "</td>"
-                + "</tr>";
+        StringBuilder row = new StringBuilder();
+        return row.append("<tr>")
+                .append("<td valign=\"top\"><b>")
+                .append(label)
+                .append("</b></td>")
+                .append("<td>")
+                .append(value)
+                .append("</td>")
+                .append("</tr>")
+                .toString();
     }
 
     /**
@@ -1005,15 +1016,17 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 lblAddressMouseClicked(evt);
             }
+
             public void mouseExited(java.awt.event.MouseEvent evt) {
                 lblAddressMouseExited(evt);
             }
+
             public void mouseEntered(java.awt.event.MouseEvent evt) {
                 lblAddressMouseEntered(evt);
             }
         });
 
-        cmbRefType.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Mandant", "Gegner", "Dritte" }));
+        cmbRefType.setModel(new javax.swing.DefaultComboBoxModel<>(new String[]{"Mandant", "Gegner", "Dritte"}));
         cmbRefType.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 cmbRefTypeActionPerformed(evt);
@@ -1059,14 +1072,14 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         javax.swing.GroupLayout detailsContentTaskPaneLayout = new javax.swing.GroupLayout(detailsContentTaskPane.getContentPane());
         detailsContentTaskPane.getContentPane().setLayout(detailsContentTaskPaneLayout);
         detailsContentTaskPaneLayout.setHorizontalGroup(
-            detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
         );
         detailsContentTaskPaneLayout.setVerticalGroup(
-            detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(detailsContentTaskPaneLayout.createSequentialGroup()
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
+                detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(detailsContentTaskPaneLayout.createSequentialGroup()
+                                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(0, 0, Short.MAX_VALUE))
         );
 
         jXTaskPane1.setExpanded(false);
@@ -1091,42 +1104,42 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         javax.swing.GroupLayout jXTaskPane1Layout = new javax.swing.GroupLayout(jXTaskPane1.getContentPane());
         jXTaskPane1.getContentPane().setLayout(jXTaskPane1Layout);
         jXTaskPane1Layout.setHorizontalGroup(
-            jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jXTaskPane1Layout.createSequentialGroup()
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(lblCustom1)
-                    .addComponent(lblCustom2)
-                    .addComponent(lblCustom3))
-                .addGap(72, 72, 72)
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(txtCustom1, javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(txtCustom2, javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(txtCustom3, javax.swing.GroupLayout.Alignment.TRAILING)))
-            .addGroup(jXTaskPane1Layout.createSequentialGroup()
-                .addComponent(jLabel2)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(txtContact))
+                jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(jXTaskPane1Layout.createSequentialGroup()
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                        .addComponent(lblCustom1)
+                                        .addComponent(lblCustom2)
+                                        .addComponent(lblCustom3))
+                                .addGap(72, 72, 72)
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                        .addComponent(txtCustom1, javax.swing.GroupLayout.Alignment.TRAILING)
+                                        .addComponent(txtCustom2, javax.swing.GroupLayout.Alignment.TRAILING)
+                                        .addComponent(txtCustom3, javax.swing.GroupLayout.Alignment.TRAILING)))
+                        .addGroup(jXTaskPane1Layout.createSequentialGroup()
+                                .addComponent(jLabel2)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(txtContact))
         );
         jXTaskPane1Layout.setVerticalGroup(
-            jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jXTaskPane1Layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(txtContact, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel2))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(txtCustom1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(lblCustom1))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(txtCustom2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(lblCustom2))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(txtCustom3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(lblCustom3))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(jXTaskPane1Layout.createSequentialGroup()
+                                .addContainerGap()
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                        .addComponent(txtContact, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(jLabel2))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                        .addComponent(txtCustom1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(lblCustom1))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                        .addComponent(txtCustom2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(lblCustom2))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                        .addComponent(txtCustom3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(lblCustom3))
+                                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         lblUnderage.setText("jLabel1");
@@ -1134,48 +1147,48 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addComponent(lblType)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(lblAddress)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addComponent(lblUnderage)
-                        .addGap(18, 18, 18)
-                        .addComponent(jLabel3)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(txtReference)
-                        .addGap(18, 18, 18)
-                        .addComponent(cmbRefType, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(cmdToAddress)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(cmdActions))
-                    .addComponent(jXTaskPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addComponent(lblType)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addComponent(lblAddress)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                                .addComponent(lblUnderage)
+                                                .addGap(18, 18, 18)
+                                                .addComponent(jLabel3)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(txtReference)
+                                                .addGap(18, 18, 18)
+                                                .addComponent(cmbRefType, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(cmdToAddress)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(cmdActions))
+                                        .addComponent(jXTaskPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addContainerGap())
         );
         layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(lblType, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(cmdActions)
-                    .addComponent(cmdToAddress)
-                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                        .addComponent(cmbRefType, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addComponent(lblAddress)
-                        .addComponent(txtReference, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addComponent(jLabel3)
-                        .addComponent(lblUnderage)))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jXTaskPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(21, Short.MAX_VALUE))
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addComponent(lblType, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGroup(layout.createSequentialGroup()
+                                .addContainerGap()
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                        .addComponent(cmdActions)
+                                        .addComponent(cmdToAddress)
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                                .addComponent(cmbRefType, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                .addComponent(lblAddress)
+                                                .addComponent(txtReference, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                .addComponent(jLabel3)
+                                                .addComponent(lblUnderage)))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jXTaskPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(21, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
@@ -831,9 +831,10 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             }
 
             // Set important information to content panel
+            StringBuilder wrapper = new StringBuilder();
+            wrapper.append("<html>");
+            wrapper.append("<table>");
             StringBuilder content = new StringBuilder();
-            content.append("<html>");
-            content.append("<table>");
             if (!this.a.getPhone().isEmpty()) {
                 content.append(getContentRow("Festnetz:", this.a.getPhone()));
             }
@@ -866,11 +867,15 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             if (!address.isEmpty()) {
                 content.append(getContentRow("Adresse:", address));
             }
-            content.append("</table>");
-            content.append("</html>");
+            wrapper.append(content.toString());
+            wrapper.append("</table>");
+            wrapper.append("</html>");
             this.detailsContent.setBorder(null);
             this.detailsContent.setContentType("text/html");
             this.detailsContent.setText(content.toString());
+            if (content.toString().isEmpty()) {
+                detailsContentTaskPane.setVisible(false);
+            }
         }
 
     }
@@ -907,7 +912,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         cmdActions = new javax.swing.JButton();
         cmdToAddress = new javax.swing.JButton();
         lblType = new javax.swing.JLabel();
-        jXTaskPane2 = new org.jdesktop.swingx.JXTaskPane();
+        detailsContentTaskPane = new org.jdesktop.swingx.JXTaskPane();
         jScrollPane1 = new javax.swing.JScrollPane();
         detailsContent = new javax.swing.JTextPane();
         jXTaskPane1 = new org.jdesktop.swingx.JXTaskPane();
@@ -1041,25 +1046,25 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         lblType.setText("  ");
         lblType.setOpaque(true);
 
-        jXTaskPane2.setExpanded(false);
-        jXTaskPane2.setForeground(new java.awt.Color(255, 255, 255));
-        jXTaskPane2.setTitle("Details");
-        jXTaskPane2.setAnimated(false);
+        detailsContentTaskPane.setExpanded(false);
+        detailsContentTaskPane.setForeground(new java.awt.Color(255, 255, 255));
+        detailsContentTaskPane.setTitle("Details");
+        detailsContentTaskPane.setAnimated(false);
 
         jScrollPane1.setBorder(null);
 
         detailsContent.setBorder(null);
         jScrollPane1.setViewportView(detailsContent);
 
-        javax.swing.GroupLayout jXTaskPane2Layout = new javax.swing.GroupLayout(jXTaskPane2.getContentPane());
-        jXTaskPane2.getContentPane().setLayout(jXTaskPane2Layout);
-        jXTaskPane2Layout.setHorizontalGroup(
-            jXTaskPane2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+        javax.swing.GroupLayout detailsContentTaskPaneLayout = new javax.swing.GroupLayout(detailsContentTaskPane.getContentPane());
+        detailsContentTaskPane.getContentPane().setLayout(detailsContentTaskPaneLayout);
+        detailsContentTaskPaneLayout.setHorizontalGroup(
+            detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
         );
-        jXTaskPane2Layout.setVerticalGroup(
-            jXTaskPane2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jXTaskPane2Layout.createSequentialGroup()
+        detailsContentTaskPaneLayout.setVerticalGroup(
+            detailsContentTaskPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(detailsContentTaskPaneLayout.createSequentialGroup()
                 .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addGap(0, 0, Short.MAX_VALUE))
         );
@@ -1149,7 +1154,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(cmdActions))
                     .addComponent(jXTaskPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jXTaskPane2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -1167,7 +1172,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                         .addComponent(jLabel3)
                         .addComponent(lblUnderage)))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jXTaskPane2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(detailsContentTaskPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jXTaskPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap(21, Short.MAX_VALUE))
@@ -1421,11 +1426,11 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
     private javax.swing.JButton cmdActions;
     private javax.swing.JButton cmdToAddress;
     private javax.swing.JTextPane detailsContent;
+    private org.jdesktop.swingx.JXTaskPane detailsContentTaskPane;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JScrollPane jScrollPane1;
     private org.jdesktop.swingx.JXTaskPane jXTaskPane1;
-    private org.jdesktop.swingx.JXTaskPane jXTaskPane2;
     private javax.swing.JLabel lblAddress;
     private javax.swing.JLabel lblCustom1;
     private javax.swing.JLabel lblCustom2;

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
@@ -691,18 +691,19 @@ import com.jdimension.jlawyer.persistence.PartyTypeBean;
 import com.jdimension.jlawyer.services.AddressServiceRemote;
 import com.jdimension.jlawyer.services.ArchiveFileServiceRemote;
 import com.jdimension.jlawyer.services.JLawyerServiceLocator;
+
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+
 import org.apache.log4j.Logger;
 import org.jlawyer.bea.model.Identity;
 import themes.colors.DefaultColorTheme;
 
 /**
- *
  * @author jens
  */
 public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements EventConsumer {
@@ -828,8 +829,57 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                     this.lblUnderage.setToolTipText("Beteiligte(r) ist minderjährig");
                 }
             }
+
+            // Set important information to content panel
+            StringBuilder content = new StringBuilder();
+            content.append("<html>");
+            content.append("<table>");
+            if (!this.a.getPhone().isEmpty()) {
+                content.append(getContentRow("Festnetz:", this.a.getPhone()));
+            }
+            if (!this.a.getMobile().isEmpty()) {
+                content.append(getContentRow("Mobil:", this.a.getMobile()));
+            }
+            if (!this.a.getEmail().isEmpty()) {
+                content.append(getContentRow("E-Mail:", this.a.getEmail()));
+            }
+            if (!this.a.getWebsite().isEmpty()) {
+                content.append(getContentRow("Website:", this.a.getWebsite()));
+            }
+            String address = "";
+            // Add street + street number
+            if (!this.a.getStreet().isEmpty() && this.a.getStreetNumber().isEmpty()) {
+                address += this.a.getStreet() + "<br>";
+            } else if (!this.a.getStreet().isEmpty() && !this.a.getStreetNumber().isEmpty()) {
+                address += this.a.getStreet() + " " + this.a.getStreetNumber() + "<br>";
+            }
+            // Add zipcode + city
+            if (!this.a.getZipCode().isEmpty() && this.a.getCity().isEmpty()) {
+                address += this.a.getZipCode() + "<br>";
+            } else if (!this.a.getZipCode().isEmpty() && !this.a.getCity().isEmpty()) {
+                address += this.a.getZipCode() + " " + this.a.getCity() + "<br>";
+            }
+            // Add country
+            if (!this.a.getCountry().isEmpty()) {
+                address += this.a.getCountry();
+            }
+            if (!address.isEmpty()) {
+                content.append(getContentRow("Adresse:", address));
+            }
+            content.append("</table>");
+            content.append("</html>");
+            this.detailsContent.setBorder(null);
+            this.detailsContent.setContentType("text/html");
+            this.detailsContent.setText(content.toString());
         }
 
+    }
+
+    private String getContentRow(String label, String value) {
+        return "<tr>"
+                + "<td><b>" + label + "</b></td>"
+                + "<td>" + value + "</td>"
+                + "</tr>";
     }
 
     /**
@@ -857,6 +907,9 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         cmdActions = new javax.swing.JButton();
         cmdToAddress = new javax.swing.JButton();
         lblType = new javax.swing.JLabel();
+        jXTaskPane2 = new org.jdesktop.swingx.JXTaskPane();
+        jScrollPane1 = new javax.swing.JScrollPane();
+        detailsContent = new javax.swing.JTextPane();
         jXTaskPane1 = new org.jdesktop.swingx.JXTaskPane();
         jLabel2 = new javax.swing.JLabel();
         lblCustom1 = new javax.swing.JLabel();
@@ -942,7 +995,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
 
         lblAddress.setFont(new java.awt.Font("Dialog", 1, 14)); // NOI18N
         lblAddress.setText("Kutschke, Jens");
-        lblAddress.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
+        lblAddress.setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
         lblAddress.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 lblAddressMouseClicked(evt);
@@ -988,9 +1041,32 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         lblType.setText("  ");
         lblType.setOpaque(true);
 
+        jXTaskPane2.setExpanded(false);
+        jXTaskPane2.setForeground(new java.awt.Color(255, 255, 255));
+        jXTaskPane2.setTitle("Details");
+        jXTaskPane2.setAnimated(false);
+
+        jScrollPane1.setBorder(null);
+
+        detailsContent.setBorder(null);
+        jScrollPane1.setViewportView(detailsContent);
+
+        javax.swing.GroupLayout jXTaskPane2Layout = new javax.swing.GroupLayout(jXTaskPane2.getContentPane());
+        jXTaskPane2.getContentPane().setLayout(jXTaskPane2Layout);
+        jXTaskPane2Layout.setHorizontalGroup(
+            jXTaskPane2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+        );
+        jXTaskPane2Layout.setVerticalGroup(
+            jXTaskPane2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(jXTaskPane2Layout.createSequentialGroup()
+                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(0, 0, Short.MAX_VALUE))
+        );
+
         jXTaskPane1.setExpanded(false);
         jXTaskPane1.setForeground(new java.awt.Color(255, 255, 255));
-        jXTaskPane1.setTitle("Details");
+        jXTaskPane1.setTitle("Zusätzliche Angaben");
         jXTaskPane1.setAnimated(false);
 
         jLabel2.setText("Ansprechpartner:");
@@ -1029,6 +1105,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
         jXTaskPane1Layout.setVerticalGroup(
             jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jXTaskPane1Layout.createSequentialGroup()
+                .addContainerGap()
                 .addGroup(jXTaskPane1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(txtContact, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel2))
@@ -1071,7 +1148,8 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                         .addComponent(cmdToAddress)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(cmdActions))
-                    .addComponent(jXTaskPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(jXTaskPane1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jXTaskPane2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -1089,8 +1167,10 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                         .addComponent(jLabel3)
                         .addComponent(lblUnderage)))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jXTaskPane2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jXTaskPane1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap(21, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -1117,7 +1197,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
             ConflictOfInterestUtils.checkForConflicts(a, ptb, EditorsRegistry.getInstance().getMainWindow());
         }
 
-        if (!this.initializing && this.a!=null) {
+        if (!this.initializing && this.a != null) {
             try {
                 ClientSettings settings = ClientSettings.getInstance();
                 JLawyerServiceLocator locator = JLawyerServiceLocator.getInstance(settings.getLookupProperties());
@@ -1340,9 +1420,12 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
     private javax.swing.JComboBox<String> cmbRefType;
     private javax.swing.JButton cmdActions;
     private javax.swing.JButton cmdToAddress;
+    private javax.swing.JTextPane detailsContent;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel3;
+    private javax.swing.JScrollPane jScrollPane1;
     private org.jdesktop.swingx.JXTaskPane jXTaskPane1;
+    private org.jdesktop.swingx.JXTaskPane jXTaskPane2;
     private javax.swing.JLabel lblAddress;
     private javax.swing.JLabel lblCustom1;
     private javax.swing.JLabel lblCustom2;

--- a/j-lawyer-client/src/de/costache/calendar/CalendarPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/CalendarPanel.java
@@ -900,6 +900,7 @@ public class CalendarPanel extends javax.swing.JPanel {
                 t.setBackgroundColor(backColor);
                 t.setForegroundColor(Color.WHITE);
                 t.setName(rev.getCalendarSetup().getDisplayName() + " (" + rev.getEventTypeName() + ")");
+                t.setUniqueKey(rev.getEventTypeName());
                 this.allCalTypes.put(rev.getCalendarSetup().getId(), t);
                 this.selectedCalTypes.add(rev.getCalendarSetup().getId());
 

--- a/j-lawyer-client/src/de/costache/calendar/model/CalendarEvent.java
+++ b/j-lawyer-client/src/de/costache/calendar/model/CalendarEvent.java
@@ -45,6 +45,7 @@ public class CalendarEvent extends Observable implements Comparable<CalendarEven
     public CalendarEvent() {
         type = new EventType();
         type.setName("default");
+        type.setUniqueKey("default");
     }
 
     public CalendarEvent(final Date start, final Date end) {

--- a/j-lawyer-client/src/de/costache/calendar/model/EventType.java
+++ b/j-lawyer-client/src/de/costache/calendar/model/EventType.java
@@ -25,6 +25,7 @@ import java.awt.Color;
 public class EventType {
 
 	private String name;
+	private String uniqueKey;
 	private Color backgroundColor;
 	private Color foregroundColor;
 
@@ -116,4 +117,11 @@ public class EventType {
 		return true;
 	}
 
+	public void setUniqueKey(String uniqueKey) {
+		this.uniqueKey = uniqueKey;
+	}
+
+	public String getUniqueKey() {
+		return uniqueKey;
+	}
 }

--- a/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
@@ -15,6 +15,7 @@
  */
 package de.costache.calendar.ui;
 
+import de.costache.calendar.model.EventType;
 import de.costache.calendar.ui.strategy.Config;
 import de.costache.calendar.JCalendar;
 import de.costache.calendar.model.CalendarEvent;
@@ -335,6 +336,23 @@ public class DayContentPanel extends JPanel {
 
     }
 
+
+    private List<CalendarEvent> sortEvents(List<CalendarEvent> events) {
+        events.sort((o1, o2) -> {
+            if (o1.getType().getUniqueKey().equals(o2.getType().getUniqueKey())) {
+                return 0;
+            } else if (o1.getType().getUniqueKey().equals("Termin")) {
+                return -1;
+            } else if (o1.getType().getUniqueKey().equals("Frist")
+                    && !o2.getType().getUniqueKey().equals("Termin")) {
+                return -1;
+            } else {
+                return 1;
+            }
+        });
+        return events;
+    }
+
     private void drawCalendarEvents(final Graphics2D graphics2d) {
 
         final EventCollection eventsCollection = EventCollectionRepository
@@ -467,7 +485,7 @@ public class DayContentPanel extends JPanel {
         int pos = 2;
         if (events.size() > 0) {
             final Config config = owner.getOwner().getConfig();
-            for (final CalendarEvent event : events) {
+            for (final CalendarEvent event : sortEvents(new ArrayList<>(events))) {
                 if (event.isHoliday())
                     continue;
                 Color bgColor = event.getType().getBackgroundColor();

--- a/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
@@ -238,13 +238,6 @@ public class DayContentPanel extends JPanel {
                 } else {
                     List holidayEvents = EventCollectionRepository.get(calendar).getHolidayEvents(owner.getDate());
                     if (holidayEvents.isEmpty()) {
-                        startDate = CalendarUtil.pixelToDate(
-                                owner.getDate(), e.getY(),
-                                getHeight());
-                        endDate = CalendarUtil.pixelToDate(owner.getDate(),
-                                e.getY(), getHeight());
-                        startDate = CalendarUtil.roundDateToHalfAnHour(startDate, false);
-                        endDate = CalendarUtil.roundDateToHalfAnHour(endDate, true);
                         setToolTipText(sdf.format(startDate) + " - " + sdf.format(endDate));
                     } else {
                         setToolTipText(calendar.getTooltipFormater().format(holidayEvents));

--- a/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/ui/DayContentPanel.java
@@ -72,8 +72,8 @@ public class DayContentPanel extends JPanel {
                 if (e.getClickCount() == 2 && e.getButton() == MouseEvent.BUTTON1) {
                     if (startSelection == null || endSelection == null)
                         return;
-                    Date startDate = CalendarUtil.pixelToDate(owner.getDate(), (int) startSelection.getY(), getHeight());
-                    Date endDate = CalendarUtil.pixelToDate(owner.getDate(), (int) endSelection.getY(), getHeight());
+                    startDate = CalendarUtil.pixelToDate(owner.getDate(), (int) startSelection.getY(), getHeight());
+                    endDate = CalendarUtil.pixelToDate(owner.getDate(), (int) endSelection.getY(), getHeight());
 
                     EventRepository.get().triggerIntervalSelection(calendar,
                             startDate, endDate);
@@ -238,10 +238,10 @@ public class DayContentPanel extends JPanel {
                 } else {
                     List holidayEvents = EventCollectionRepository.get(calendar).getHolidayEvents(owner.getDate());
                     if (holidayEvents.isEmpty()) {
-                        Date startDate = CalendarUtil.pixelToDate(
+                        startDate = CalendarUtil.pixelToDate(
                                 owner.getDate(), e.getY(),
                                 getHeight());
-                        Date endDate = CalendarUtil.pixelToDate(owner.getDate(),
+                        endDate = CalendarUtil.pixelToDate(owner.getDate(),
                                 e.getY(), getHeight());
                         startDate = CalendarUtil.roundDateToHalfAnHour(startDate, false);
                         endDate = CalendarUtil.roundDateToHalfAnHour(endDate, true);


### PR DESCRIPTION
Closes #1662 

This also renames the old "Details" to "Zusätzliche Angaben" which would be more fitting I guess.
Added fields are at the moment:
- Festnetz
- Mobil
- E-Mail
- Website
- Adresse

Closed State:
![image](https://user-images.githubusercontent.com/11789478/170087312-ce78d402-e0f8-4fbf-8e18-a74ab965cedd.png)

Open State:
![image](https://user-images.githubusercontent.com/11789478/170087346-115804da-415c-46a1-bf66-86dc65eb3bb7.png)

No content:
![image](https://user-images.githubusercontent.com/11789478/170087440-93d22750-3056-41f2-be21-8d65962b68ae.png)

If there is no content available, the pane is hidden.


Sidenote: this MR contains the Commit from #1661 as I previously worked only on the main branch in the fork. 
Sorry for the inconvenience. This MR should await the other one to be merged first (→ Draft).