### PR TITLE
Feature/search az

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsAdvancedSearchThread.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsAdvancedSearchThread.java
@@ -691,6 +691,7 @@ public class ArchiveFileReviewsAdvancedSearchThread implements Runnable {
     private int typeSearchMode = 0;
     private Date toDate = null;
     private Date fromDate = null;
+    private String fileNumber = null;
 
     /**
      * Creates a new instance of ArchiveFileReviewsAdvancedSearchThread
@@ -702,13 +703,14 @@ public class ArchiveFileReviewsAdvancedSearchThread implements Runnable {
      * @param fromDate
      * @param toDate
      */
-    public ArchiveFileReviewsAdvancedSearchThread(Component owner, JTable target, int statusSearchMode, int typeSearchMode, Date fromDate, Date toDate) {
+    public ArchiveFileReviewsAdvancedSearchThread(Component owner, JTable target, int statusSearchMode, int typeSearchMode, Date fromDate, Date toDate, String fileNumber) {
         this.owner = owner;
         this.target = target;
         this.statusSearchMode = statusSearchMode;
         this.typeSearchMode = typeSearchMode;
         this.toDate = toDate;
         this.fromDate = fromDate;
+        this.fileNumber = fileNumber;
     }
 
     @Override
@@ -720,6 +722,10 @@ public class ArchiveFileReviewsAdvancedSearchThread implements Runnable {
 
             CalendarServiceRemote calService = locator.lookupCalendarServiceRemote();
             dtos = calService.searchReviews(statusSearchMode, typeSearchMode, fromDate, toDate);
+
+            if (fileNumber != null && !fileNumber.isEmpty()) {
+                dtos.removeIf(bean -> !bean.getArchiveFileKey().getFileNumber().contains(fileNumber));
+            }
 
         } catch (Exception ex) {
             log.error("Error connecting to server", ex);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.form
@@ -170,6 +170,8 @@
                           <Component id="labelSearchAZ" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="inputSearchAZ" min="-2" pref="127" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="jLabel6" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
@@ -217,6 +219,7 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="labelSearchAZ" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="inputSearchAZ" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel6" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
               </Group>
@@ -356,9 +359,18 @@
           </Properties>
         </Component>
         <Component class="javax.swing.JTextField" name="inputSearchAZ">
+          <Properties>
+            <Property name="toolTipText" type="java.lang.String" value=""/>
+          </Properties>
           <Events>
-            <EventHandler event="caretUpdate" listener="javax.swing.event.CaretListener" parameters="javax.swing.event.CaretEvent" handler="inputSearchAZCaretUpdate"/>
+            <EventHandler event="keyPressed" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="inputSearchAZKeyPressed"/>
           </Events>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel6">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="&#x21b5;"/>
+            <Property name="toolTipText" type="java.lang.String" value="Zum Suchen &lt;Enter&gt; dr&#xfc;cken"/>
+          </Properties>
         </Component>
       </SubComponents>
     </Container>

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.form
@@ -73,7 +73,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="247" max="32767" attributes="0"/>
+              <Component id="jScrollPane1" pref="218" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -120,48 +120,58 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
+              <Group type="102" attributes="0">
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="jLabel5" alignment="0" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <EmptySpace min="-2" pref="15" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" attributes="0">
-                                  <Component id="rdAllStatuses" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="rdDoneStatus" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="rdNotDoneStatus" min="-2" max="-2" attributes="0"/>
+                              <Group type="102" alignment="0" attributes="0">
+                                  <Group type="103" groupAlignment="0" attributes="0">
+                                      <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      <Component id="jLabel5" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <EmptySpace min="-2" pref="15" max="-2" attributes="0"/>
+                                  <Group type="103" groupAlignment="0" attributes="0">
+                                      <Group type="102" attributes="0">
+                                          <Component id="rdAllStatuses" min="-2" max="-2" attributes="0"/>
+                                          <EmptySpace max="-2" attributes="0"/>
+                                          <Component id="rdDoneStatus" min="-2" max="-2" attributes="0"/>
+                                          <EmptySpace max="-2" attributes="0"/>
+                                          <Component id="rdNotDoneStatus" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                      <Group type="102" attributes="0">
+                                          <Component id="rdAllTypes" min="-2" max="-2" attributes="0"/>
+                                          <EmptySpace max="-2" attributes="0"/>
+                                          <Component id="rdTypeRespite" min="-2" max="-2" attributes="0"/>
+                                          <EmptySpace max="-2" attributes="0"/>
+                                          <Component id="rdTypeReview" min="-2" max="-2" attributes="0"/>
+                                          <EmptySpace max="-2" attributes="0"/>
+                                          <Component id="rdTypeEvent" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                  </Group>
                               </Group>
-                              <Group type="102" attributes="0">
-                                  <Component id="rdAllTypes" min="-2" max="-2" attributes="0"/>
+                              <Group type="102" alignment="0" attributes="0">
+                                  <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="rdTypeRespite" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="rdTypeReview" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="rdTypeEvent" min="-2" max="-2" attributes="0"/>
+                                  <Component id="txtFromDate" min="-2" pref="157" max="-2" attributes="0"/>
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
+                                  <Component id="txtToDate" min="-2" pref="162" max="-2" attributes="0"/>
                               </Group>
                           </Group>
+                          <EmptySpace type="separate" max="-2" attributes="0"/>
+                          <Component id="cmdReset" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <Group type="102" alignment="0" attributes="0">
-                          <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="txtFromDate" min="-2" pref="157" max="-2" attributes="0"/>
-                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
-                          <Component id="txtToDate" min="-2" pref="162" max="-2" attributes="0"/>
+                          <Component id="labelSearchAZ" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="inputSearchAZ" min="-2" pref="127" max="-2" attributes="0"/>
                       </Group>
                   </Group>
-                  <EmptySpace type="separate" max="-2" attributes="0"/>
-                  <Component id="cmdReset" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="32767" attributes="0"/>
               </Group>
           </Group>
@@ -202,6 +212,11 @@
                           </Group>
                       </Group>
                       <Component id="cmdReset" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="labelSearchAZ" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="inputSearchAZ" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
               </Group>
@@ -333,6 +348,16 @@
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="rdTypeEventActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JLabel" name="labelSearchAZ">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="nach Aktenzeichen:"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="inputSearchAZ">
+          <Events>
+            <EventHandler event="caretUpdate" listener="javax.swing.event.CaretListener" parameters="javax.swing.event.CaretEvent" handler="inputSearchAZCaretUpdate"/>
           </Events>
         </Component>
       </SubComponents>

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.java
@@ -701,6 +701,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     
     private String detailsEditorClass;
     private Image backgroundImage=null;
+    private String currentAZValue = null;
     
     /**
      * Creates new form ArchiveFileReviewsFindPanel
@@ -765,6 +766,8 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
         jLabel1 = new javax.swing.JLabel();
         cmdReset = new javax.swing.JButton();
         rdTypeEvent = new javax.swing.JRadioButton();
+        labelSearchAZ = new javax.swing.JLabel();
+        inputSearchAZ = new javax.swing.JTextField();
         jLabel18 = new javax.swing.JLabel();
         lblPanelTitle = new javax.swing.JLabel();
         jPanel2 = new javax.swing.JPanel();
@@ -903,45 +906,60 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
             }
         });
 
+        labelSearchAZ.setText("nach Aktenzeichen:");
+
+        inputSearchAZ.addCaretListener(new javax.swing.event.CaretListener() {
+            public void caretUpdate(javax.swing.event.CaretEvent evt) {
+                inputSearchAZCaretUpdate(evt);
+            }
+        });
+
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(jPanel1Layout.createSequentialGroup()
-                .add(6, 6, 6)
                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                     .add(jPanel1Layout.createSequentialGroup()
-                        .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(jLabel1)
-                            .add(jLabel5))
-                        .add(15, 15, 15)
-                        .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(jPanel1Layout.createSequentialGroup()
-                                .add(rdAllStatuses)
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(rdDoneStatus)
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(rdNotDoneStatus))
-                            .add(jPanel1Layout.createSequentialGroup()
-                                .add(rdAllTypes)
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(rdTypeRespite)
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(rdTypeReview)
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(rdTypeEvent))))
-                    .add(jPanel1Layout.createSequentialGroup()
-                        .add(jLabel4)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(jLabel2)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(txtFromDate, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 157, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(jLabel3)
                         .add(6, 6, 6)
-                        .add(txtToDate, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 162, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
-                .add(18, 18, 18)
-                .add(cmdReset)
+                        .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                            .add(jPanel1Layout.createSequentialGroup()
+                                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                    .add(jLabel1)
+                                    .add(jLabel5))
+                                .add(15, 15, 15)
+                                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                    .add(jPanel1Layout.createSequentialGroup()
+                                        .add(rdAllStatuses)
+                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                        .add(rdDoneStatus)
+                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                        .add(rdNotDoneStatus))
+                                    .add(jPanel1Layout.createSequentialGroup()
+                                        .add(rdAllTypes)
+                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                        .add(rdTypeRespite)
+                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                        .add(rdTypeReview)
+                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                        .add(rdTypeEvent))))
+                            .add(jPanel1Layout.createSequentialGroup()
+                                .add(jLabel4)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(jLabel2)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(txtFromDate, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 157, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(jLabel3)
+                                .add(6, 6, 6)
+                                .add(txtToDate, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 162, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                        .add(18, 18, 18)
+                        .add(cmdReset))
+                    .add(jPanel1Layout.createSequentialGroup()
+                        .addContainerGap()
+                        .add(labelSearchAZ)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 127, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
                 .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         jPanel1Layout.setVerticalGroup(
@@ -973,6 +991,10 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
                             .add(rdDoneStatus)
                             .add(rdAllStatuses)))
                     .add(cmdReset))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(labelSearchAZ)
+                    .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap())
         );
 
@@ -1145,7 +1167,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
         if(this.rdTypeEvent.isSelected())
             type=ArchiveFileConstants.REVIEWTYPE_EVENT;
         
-        new Thread(new ArchiveFileReviewsAdvancedSearchThread(this, this.tblResults, status, type, fromDate, toDate)).start();
+        new Thread(new ArchiveFileReviewsAdvancedSearchThread(this, this.tblResults, status, type, fromDate, toDate, inputSearchAZ.getText())).start();
         
     }//GEN-LAST:event_cmdRefreshActionPerformed
 
@@ -1241,6 +1263,14 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     private void rdTypeEventActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rdTypeEventActionPerformed
         this.cmdRefreshActionPerformed(null);
     }//GEN-LAST:event_rdTypeEventActionPerformed
+
+    private void inputSearchAZCaretUpdate(javax.swing.event.CaretEvent evt) {//GEN-FIRST:event_inputSearchAZCaretUpdate
+        String newValue = inputSearchAZ.getText();
+        if(!newValue.equals(currentAZValue)){
+            currentAZValue = newValue;
+            this.cmdRefreshActionPerformed(null);            
+        }
+    }//GEN-LAST:event_inputSearchAZCaretUpdate
     
     private ReviewsStub getPrintValues() {
         ArrayList<ArchiveFileReviewsBean> revList=new ArrayList<>();
@@ -1299,6 +1329,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     private javax.swing.JButton cmdReset;
     private javax.swing.ButtonGroup grpStatus;
     private javax.swing.ButtonGroup grpType;
+    private javax.swing.JTextField inputSearchAZ;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel2;
@@ -1308,6 +1339,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JLabel labelSearchAZ;
     protected javax.swing.JLabel lblPanelTitle;
     private javax.swing.JMenuItem mnuOpenArchiveFile;
     private javax.swing.JPopupMenu popupArchiveFileActions;

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsFindPanel.java
@@ -701,7 +701,6 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     
     private String detailsEditorClass;
     private Image backgroundImage=null;
-    private String currentAZValue = null;
     
     /**
      * Creates new form ArchiveFileReviewsFindPanel
@@ -768,6 +767,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
         rdTypeEvent = new javax.swing.JRadioButton();
         labelSearchAZ = new javax.swing.JLabel();
         inputSearchAZ = new javax.swing.JTextField();
+        jLabel6 = new javax.swing.JLabel();
         jLabel18 = new javax.swing.JLabel();
         lblPanelTitle = new javax.swing.JLabel();
         jPanel2 = new javax.swing.JPanel();
@@ -908,11 +908,15 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
 
         labelSearchAZ.setText("nach Aktenzeichen:");
 
-        inputSearchAZ.addCaretListener(new javax.swing.event.CaretListener() {
-            public void caretUpdate(javax.swing.event.CaretEvent evt) {
-                inputSearchAZCaretUpdate(evt);
+        inputSearchAZ.setToolTipText("");
+        inputSearchAZ.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyPressed(java.awt.event.KeyEvent evt) {
+                inputSearchAZKeyPressed(evt);
             }
         });
+
+        jLabel6.setText("↵");
+        jLabel6.setToolTipText("Zum Suchen <Enter> drücken");
 
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
@@ -959,7 +963,9 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
                         .addContainerGap()
                         .add(labelSearchAZ)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 127, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                        .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 127, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(jLabel6)))
                 .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         jPanel1Layout.setVerticalGroup(
@@ -994,7 +1000,8 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(labelSearchAZ)
-                    .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                    .add(inputSearchAZ, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(jLabel6))
                 .addContainerGap())
         );
 
@@ -1070,7 +1077,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
                         .add(jLabel18)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(lblPanelTitle, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 566, Short.MAX_VALUE)))
+                        .add(lblPanelTitle, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 566, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -1085,7 +1092,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(jPanel1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 247, Short.MAX_VALUE)
+                .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 218, Short.MAX_VALUE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -1264,13 +1271,11 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
         this.cmdRefreshActionPerformed(null);
     }//GEN-LAST:event_rdTypeEventActionPerformed
 
-    private void inputSearchAZCaretUpdate(javax.swing.event.CaretEvent evt) {//GEN-FIRST:event_inputSearchAZCaretUpdate
-        String newValue = inputSearchAZ.getText();
-        if(!newValue.equals(currentAZValue)){
-            currentAZValue = newValue;
+    private void inputSearchAZKeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_inputSearchAZKeyPressed
+        if(evt.getKeyCode() == KeyEvent.VK_ENTER){            
             this.cmdRefreshActionPerformed(null);            
         }
-    }//GEN-LAST:event_inputSearchAZCaretUpdate
+    }//GEN-LAST:event_inputSearchAZKeyPressed
     
     private ReviewsStub getPrintValues() {
         ArrayList<ArchiveFileReviewsBean> revList=new ArrayList<>();
@@ -1336,6 +1341,7 @@ public class ArchiveFileReviewsFindPanel extends javax.swing.JPanel implements T
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel5;
+    private javax.swing.JLabel jLabel6;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JScrollPane jScrollPane1;


### PR DESCRIPTION
This adds the possibility to search by AZ (#1551 )
![image](https://user-images.githubusercontent.com/11789478/175035828-02b44bc2-ddf5-442d-b6e0-eacadb50c3d6.png)

With something in the search input:
![image](https://user-images.githubusercontent.com/11789478/175035878-19c3bd32-c123-4e2f-843c-4f1611fda4fc.png)

The search results are refreshed once something is typed into the text field.
This might need to be replaced with a search button? @j-dimension 

The search uses the .contains method to also allow partial searching, e.g. all AZs that end with /22.