### PR TITLE
fixed: calculationPlugins needed horizontal scrolling #2739

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/plugins/calculation/CalculationPluginDialog.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/plugins/calculation/CalculationPluginDialog.form
@@ -57,7 +57,7 @@
   <SubComponents>
     <Container class="javax.swing.JScrollPane" name="scrollMain">
       <Properties>
-        <Property name="horizontalScrollBarPolicy" type="int" value="31"/>
+        <Property name="horizontalScrollBarPolicy" type="int" value="30"/>
       </Properties>
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
     </Container>

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/plugins/calculation/CalculationPluginDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/plugins/calculation/CalculationPluginDialog.java
@@ -694,13 +694,8 @@ public class CalculationPluginDialog extends javax.swing.JDialog {
         this.scrollMain.setViewportView(pluginUi);
         // pack after injecting content so width follows content's preferred size
         this.pack();
-        // widen slightly to compensate for vertical scrollbar width
-        try {
-            int extra = this.scrollMain.getVerticalScrollBar().getPreferredSize().width + 4;
-            this.setSize(this.getWidth() + extra, this.getHeight());
-        } catch (Throwable t) {
-            // ignore sizing errors
-        }
+        // adjust size within screen limits and allow scrolling as needed
+        adjustSizeToScreen();
     }
     
     /**
@@ -716,12 +711,51 @@ public class CalculationPluginDialog extends javax.swing.JDialog {
         this.scrollMain.getVerticalScrollBar().setUnitIncrement(16);
         // pack after injecting content so width follows content's preferred size
         this.pack();
-        // widen slightly to compensate for vertical scrollbar width
+        // adjust size within screen limits and allow scrolling as needed
+        adjustSizeToScreen();
+    }
+
+    private void adjustSizeToScreen() {
         try {
-            int extra = this.scrollMain.getVerticalScrollBar().getPreferredSize().width + 4;
-            this.setSize(this.getWidth() + extra, this.getHeight());
+            // Ensure horizontal scrollbars can appear when necessary
+            scrollMain.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+
+            java.awt.GraphicsConfiguration gc = getGraphicsConfiguration();
+            java.awt.Rectangle bounds;
+            if (gc != null) {
+                java.awt.Insets insets = java.awt.Toolkit.getDefaultToolkit().getScreenInsets(gc);
+                java.awt.Rectangle b = gc.getBounds();
+                bounds = new java.awt.Rectangle(
+                        b.x + insets.left,
+                        b.y + insets.top,
+                        b.width - insets.left - insets.right,
+                        b.height - insets.top - insets.bottom);
+            } else {
+                bounds = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+            }
+
+            int maxW = (int) Math.floor(bounds.width * 0.9);
+            int maxH = (int) Math.floor(bounds.height * 0.9);
+
+            int curW = getWidth();
+            int curH = getHeight();
+
+            // Small extra width to compensate potential vertical scrollbar
+            int extra = 0;
+            try {
+                extra = this.scrollMain.getVerticalScrollBar().getPreferredSize().width + 4;
+            } catch (Throwable ignore) { }
+
+            int targetW = Math.min(curW + extra, maxW);
+            int targetH = Math.min(curH, maxH);
+
+            setSize(targetW, targetH);
+
+            // Center relative to owner if present, otherwise screen
+            java.awt.Window owner = getOwner();
+            setLocationRelativeTo(owner != null ? owner : null);
         } catch (Throwable t) {
-            // ignore sizing errors
+            // best-effort sizing; ignore failures
         }
     }
     
@@ -754,8 +788,8 @@ public class CalculationPluginDialog extends javax.swing.JDialog {
         lblUpdated.setFont(lblUpdated.getFont().deriveFont(lblUpdated.getFont().getSize()-2f));
         lblUpdated.setText("aktualisiert am");
 
-        // avoid horizontal scrolling for plugin UIs; we expand width instead
-        scrollMain.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        // allow horizontal scrolling when needed
+        scrollMain.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);


### PR DESCRIPTION
 Scrollbar-Policy: Horizontal auf “as needed”
    - Datei j-lawyer-client/src/com/jdimension/jlawyer/client/plugins/calculation/
CalculationPluginDialog.form: horizontalScrollBarPolicy von 31 (NEVER) auf 30 (AS_NEEDED)
gesetzt.
    - Datei CalculationPluginDialog.java: in initComponents() ebenfalls auf
HORIZONTAL_SCROLLBAR_AS_NEEDED geändert.
- Automatische Größenbegrenzung: Maximal 90% des nutzbaren Bildschirmbereichs
    - Neue Methode adjustSizeToScreen():
    - Ermittelt nutzbare Bounds (unter Berücksichtigung der Screen Insets/Taskleiste).
    - Begrenzt Breite/Höhe auf 90% dieser Bounds.
    - Fügt optional ein paar Pixel Breite hinzu, um eine durch die vertikale Scrollbar
verursachte unnötige horizontale Scrollbar zu vermeiden (ohne über 90% zu gehen).
    - Zentriert das Dialogfenster (relativ zum Owner, sonst Bildschirm).
- Aufruf dieser Methode in beiden Konstruktoren nach pack() und Setzen des
Plugin-UI-Components.
- Scrollverhalten: Vertikales Scrolling bleibt aktiv, unitIncrement auf 16 bleibt
erhalten.



 Große Bildschirme: Kein horizontaler Scrollbalken, volle Breite sichtbar.
- Kleine Bildschirme: Dialog wird auf 90% begrenzt; horizontaler Scrollbalken erscheint
bei Bedarf, UI bleibt vollständig erreichbar.

