### PR TITLE
Open calendar in sep. Window, from Calendarpanel and ArchiveFilePanel

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -4445,8 +4445,13 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
     private void applyConflictRenderers() {
         // Default renderer for Object.class
         this.tblReviewReasons.setDefaultRenderer(Object.class, new ConflictAwareDefaultRenderer());
-        // Boolean renderer should also honor conflict foreground color
-        this.tblReviewReasons.setDefaultRenderer(Boolean.class, new ConflictAwareDefaultRenderer());
+        // Boolean renderer should also honor conflict foreground color, but keep checkbox rendering
+        try {
+            javax.swing.table.TableCellRenderer boolBase = this.tblReviewReasons.getDefaultRenderer(Boolean.class);
+            this.tblReviewReasons.setDefaultRenderer(Boolean.class, new ConflictAwareUserRenderer(boolBase));
+        } catch (Throwable t) {
+            this.tblReviewReasons.setDefaultRenderer(Boolean.class, new ConflictAwareDefaultRenderer());
+        }
         // Column 5 has a custom renderer: wrap it to keep user rendering + conflict style
         try {
             javax.swing.table.TableColumn col = this.tblReviewReasons.getColumnModel().getColumn(5);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/NewEventPanel.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/NewEventPanel.form
@@ -48,6 +48,8 @@
                           <Component id="radioEventTypeEvent" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="calendarSelectionButton" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="btnOpenCalendar" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                   <Component id="jLabel23" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -86,6 +88,7 @@
           <Group type="102" alignment="0" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="calendarSelectionButton" alignment="1" min="-2" max="-2" attributes="0"/>
+                  <Component id="btnOpenCalendar" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Group type="103" alignment="0" groupAlignment="3" attributes="0">
                       <Component id="radioEventTypeFollowUp" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="radioEventTypeRespite" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -135,6 +138,24 @@
     </DimensionLayout>
   </Layout>
   <SubComponents>
+    <Component class="javax.swing.JButton" name="btnOpenCalendar">
+      <Properties>
+        <Property name="toolTipText" type="java.lang.String" value="Kalender in separatem Fenster &#xf6;ffnen"/>
+        <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
+          <Image iconType="3" name="/icons16/material/baseline_splitscreen_black_48dp.png"/>
+        </Property>
+        <Property name="focusPainted" type="boolean" value="false"/>
+        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
+          <Insets value="[2, 2, 2, 2]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="26, 26"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnOpenCalendarActionPerformed"/>
+      </Events>
+    </Component>
     <Component class="javax.swing.JRadioButton" name="radioEventTypeFollowUp">
       <Properties>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">

--- a/j-lawyer-client/src/de/costache/calendar/ui/HeaderPanel.java
+++ b/j-lawyer-client/src/de/costache/calendar/ui/HeaderPanel.java
@@ -47,6 +47,7 @@ public class HeaderPanel extends JPanel {
 	private JButton monthButton;
         
         private JButton todayButton;
+        private JButton windowButton;
 
 	/**
 	 * Creates a new instance of {@link HeaderPanel}
@@ -70,6 +71,7 @@ public class HeaderPanel extends JPanel {
 		monthButton = new JButton();
                 monthButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/calendar_month.png")));
                 todayButton=new JButton();
+                windowButton=new JButton();
                 todayButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/calendar_today.png")));
 
 		scrollLeftButton = new JButton();
@@ -81,6 +83,8 @@ public class HeaderPanel extends JPanel {
 		weekButton.setText(strWeek);
 		monthButton.setText(strMonth);
                 todayButton.setText("Heute");
+                windowButton.setText("2. Fenster");
+                windowButton.setToolTipText("Kalender in separatem Fenster öffnen");
                 
 
 		scrollLeftButton.setBorderPainted(false);
@@ -152,11 +156,17 @@ public class HeaderPanel extends JPanel {
                 sep.setOrientation(SwingConstants.VERTICAL);
 		this.add(sep, c);
                 c.gridx = 7;
-		c.gridy = 0;
-		c.weightx = 0.0;
-		c.fill = GridBagConstraints.BOTH;
-		c.insets = new Insets(10, 0, 10, 10);
-		this.add(todayButton, c);
+                c.gridy = 0;
+                c.weightx = 0.0;
+                c.fill = GridBagConstraints.BOTH;
+                c.insets = new Insets(10, 0, 10, 10);
+                this.add(todayButton, c);
+                c.gridx = 8;
+                c.gridy = 0;
+                c.weightx = 0.0;
+                c.fill = GridBagConstraints.BOTH;
+                c.insets = new Insets(10, 0, 10, 10);
+                this.add(windowButton, c);
 	}
 
 	/**
@@ -194,9 +204,13 @@ public class HeaderPanel extends JPanel {
 		return monthButton;
 	}
         
-        public JButton getTodayButton() {
-		return todayButton;
-	}
+       public JButton getTodayButton() {
+           return todayButton;
+       }
+
+        public JButton getWindowButton() {
+            return windowButton;
+        }
 
 	/**
 	 * @return the intervalLabel


### PR DESCRIPTION
- Header: new “2nd Window” button (main calendar)
- NewEventPanel: “2nd Window” button, loads all open events; “Refresh”  = server reload
- Case popout: disable “Open Case” with warning dialog
- Main calendar popout: “Refresh” loads all open events from server;  align view to main calendar
- CalendarPanel: live updates via EventBroker (ReviewAdded/Updated)

#2053

betrifft auch:  #923