### PR TITLE
Feat/transcribe button in chat

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.form
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.form
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.8" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JDialogFormInfo">
+  <NonVisualComponents>
+    <Container class="javax.swing.JPopupMenu" name="popAssistant">
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout">
+        <Property name="useNullLayout" type="boolean" value="true"/>
+      </Layout>
+    </Container>
+  </NonVisualComponents>
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="2"/>
     <Property name="title" type="java.lang.String" value="Assistent Ingo"/>
@@ -61,7 +69,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="pnlParameters" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="splitInputOutput" pref="391" max="32767" attributes="0"/>
+              <Component id="splitInputOutput" pref="388" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" max="-2" attributes="0">
                   <Component id="cmdClose" min="-2" max="-2" attributes="0"/>
@@ -124,14 +132,16 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="lblRequestType" max="32767" attributes="0"/>
+                  <Component id="lblRequestType" min="-2" pref="184" max="-2" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="cmbDevices" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="cmdTranscribe" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="cmdSubmit" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="cmdInterrupt" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="cmdTranscribe" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Component id="cmdPrompt" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="cmdResetChat" min="-2" max="-2" attributes="0"/>
@@ -144,16 +154,17 @@
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="lblRequestType" alignment="0" max="32767" attributes="0"/>
+                      <Component id="cmdTranscribe" alignment="0" max="32767" attributes="0"/>
+                      <Component id="cmdInterrupt" alignment="1" max="32767" attributes="0"/>
+                      <Component id="cmdSubmit" alignment="0" max="32767" attributes="0"/>
+                      <Group type="103" alignment="0" groupAlignment="3" attributes="0">
+                          <Component id="lblRequestType" alignment="3" max="32767" attributes="0"/>
+                          <Component id="cmbDevices" alignment="3" max="32767" attributes="0"/>
+                      </Group>
                       <Group type="102" attributes="0">
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="cmdResetChat" min="-2" max="-2" attributes="0"/>
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="cmdPrompt" min="-2" max="-2" attributes="0"/>
-                                  <Component id="cmdTranscribe" min="-2" max="-2" attributes="0"/>
-                                  <Component id="cmdInterrupt" min="-2" max="-2" attributes="0"/>
-                                  <Component id="cmdSubmit" alignment="1" min="-2" max="-2" attributes="0"/>
-                              </Group>
+                          <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                              <Component id="cmdResetChat" alignment="0" max="32767" attributes="0"/>
+                              <Component id="cmdPrompt" alignment="0" max="32767" attributes="0"/>
                           </Group>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
@@ -204,7 +215,7 @@
             <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/icons16/material/baseline_mic_black_48dp.png"/>
             </Property>
-            <Property name="toolTipText" type="java.lang.String" value="Sprachaufnahme starten und transkribieren"/>
+            <Property name="toolTipText" type="java.lang.String" value="KI-Anfrage diktieren"/>
             <Property name="enabled" type="boolean" value="false"/>
           </Properties>
           <Events>
@@ -232,6 +243,21 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cmdResetChatActionPerformed"/>
           </Events>
+        </Component>
+        <Component class="javax.swing.JComboBox" name="cmbDevices">
+          <Properties>
+            <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+              <StringArray count="4">
+                <StringItem index="0" value="Item 1"/>
+                <StringItem index="1" value="Item 2"/>
+                <StringItem index="2" value="Item 3"/>
+                <StringItem index="3" value="Item 4"/>
+              </StringArray>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.java
@@ -672,7 +672,6 @@ import com.jdimension.jlawyer.ai.OutputData;
 import com.jdimension.jlawyer.ai.Parameter;
 import com.jdimension.jlawyer.ai.ParameterData;
 import com.jdimension.jlawyer.persistence.AssistantPrompt;
-import com.jdimension.jlawyer.client.assistant.AssistantAccess;
 import com.jdimension.jlawyer.client.editors.files.ArchiveFilePanel;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
@@ -697,7 +696,6 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -726,6 +724,7 @@ import javax.swing.SwingWorker;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
+import javax.sound.sampled.Mixer;
 import javax.sound.sampled.TargetDataLine;
 import org.apache.log4j.Logger;
 import themes.colors.DefaultColorTheme;
@@ -944,6 +943,9 @@ public class AssistantChatDialog extends javax.swing.JDialog {
 
         // Save original button background
         this.cmdTranscribeOriginalBackground = this.cmdTranscribe.getBackground();
+        
+        this.cmbDevices.removeAllItems();
+        AudioUtils.populateMicrophoneDevices(this.cmbDevices);
     }
 
     @Override
@@ -982,6 +984,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
         cmdTranscribe = new javax.swing.JButton();
         cmdPrompt = new javax.swing.JButton();
         cmdResetChat = new javax.swing.JButton();
+        cmbDevices = new javax.swing.JComboBox<>();
         progress = new javax.swing.JProgressBar();
         pnlParameters = new javax.swing.JPanel();
         splitInputOutput = new javax.swing.JSplitPane();
@@ -1047,7 +1050,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
         });
 
         cmdTranscribe.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/material/baseline_mic_black_48dp.png"))); // NOI18N
-        cmdTranscribe.setToolTipText("Sprachaufnahme starten und transkribieren");
+        cmdTranscribe.setToolTipText("KI-Anfrage diktieren");
         cmdTranscribe.setEnabled(false);
         cmdTranscribe.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -1056,7 +1059,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
         });
 
         cmdPrompt.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/material/j-lawyer-ai.png"))); // NOI18N
-        cmdPrompt.setToolTipText("Eigene Prompts auswählen");
+        cmdPrompt.setToolTipText("Eigene Prompts ausw\\u00e4hlen");
         cmdPrompt.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseReleased(java.awt.event.MouseEvent evt) {
                 cmdPromptMouseReleased(evt);
@@ -1071,20 +1074,24 @@ public class AssistantChatDialog extends javax.swing.JDialog {
             }
         });
 
+        cmbDevices.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+
         javax.swing.GroupLayout pnlTitleLayout = new javax.swing.GroupLayout(pnlTitle);
         pnlTitle.setLayout(pnlTitleLayout);
         pnlTitleLayout.setHorizontalGroup(
             pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(pnlTitleLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(lblRequestType, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(lblRequestType, javax.swing.GroupLayout.PREFERRED_SIZE, 184, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(cmbDevices, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(cmdTranscribe)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cmdSubmit)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cmdInterrupt)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(cmdTranscribe)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGap(18, 18, 18)
                 .addComponent(cmdPrompt)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cmdResetChat)
@@ -1095,15 +1102,16 @@ public class AssistantChatDialog extends javax.swing.JDialog {
             .addGroup(pnlTitleLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(lblRequestType, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cmdTranscribe, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cmdInterrupt, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cmdSubmit, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addGroup(pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(lblRequestType, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(cmbDevices))
                     .addGroup(pnlTitleLayout.createSequentialGroup()
-                        .addGroup(pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(cmdResetChat)
-                            .addGroup(pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                .addComponent(cmdPrompt)
-                                .addComponent(cmdTranscribe)
-                                .addComponent(cmdInterrupt)
-                                .addComponent(cmdSubmit, javax.swing.GroupLayout.Alignment.TRAILING)))
+                        .addGroup(pnlTitleLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(cmdResetChat, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(cmdPrompt, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
@@ -1188,7 +1196,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(pnlParameters, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(splitInputOutput, javax.swing.GroupLayout.DEFAULT_SIZE, 391, Short.MAX_VALUE)
+                .addComponent(splitInputOutput, javax.swing.GroupLayout.DEFAULT_SIZE, 388, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                     .addComponent(cmdClose)
@@ -1536,6 +1544,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
     private void cmdTranscribeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdTranscribeActionPerformed
         if (!isRecording) {
             startRecording();
+            ClientSettings.getInstance().setConfiguration(ClientSettings.CONF_SOUND_LASTRECORDINGDEVICE, (String) this.cmbDevices.getSelectedItem());
         } else {
             try {
                 stopRecording();
@@ -1619,6 +1628,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JComboBox<String> cmbDevices;
     private javax.swing.JButton cmdClose;
     private javax.swing.JButton cmdCopy;
     private javax.swing.JButton cmdInterrupt;
@@ -1665,7 +1675,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
     private List<InputData> getTranscribeInputs(byte[] wavContent) {
         ArrayList<InputData> inputs = new ArrayList<>();
         InputData i = new InputData();
-        i.setFileName("recording.wav");
+        i.setFileName("Sounddatei.wav");
         i.setType("file");
         i.setBase64(true);
         i.setData(wavContent);
@@ -1677,9 +1687,27 @@ public class AssistantChatDialog extends javax.swing.JDialog {
         try {
             AudioFormat audioFormat = AudioUtils.getAudioFormat();
 
-            // Use default microphone (no device selection)
+            // Get selected mixer device name from dropdown
+            String selectedDeviceName = (String) this.cmbDevices.getSelectedItem();
+
+            Mixer.Info[] mixerInfos = AudioSystem.getMixerInfo();
+            Mixer.Info selectedMixerInfo = null;
+            for (Mixer.Info mixerInfo : mixerInfos) {
+                if (mixerInfo.getName().equals(selectedDeviceName)) {
+                    selectedMixerInfo = mixerInfo;
+                    break;
+                }
+            }
+
+            if (selectedMixerInfo == null) {
+                log.error("Selected mixer device not found.");
+                return;
+            }
+
+            Mixer mixer = AudioSystem.getMixer(selectedMixerInfo);
+
             DataLine.Info dataLineInfo = new DataLine.Info(TargetDataLine.class, audioFormat);
-            targetDataLine = (TargetDataLine) AudioSystem.getLine(dataLineInfo);
+            targetDataLine = (TargetDataLine) mixer.getLine(dataLineInfo);
             targetDataLine.open(audioFormat);
             targetDataLine.start();
 


### PR DESCRIPTION
#3133

**1. Voice Transcription Button**

  - Icon: Microphone icon (baseline_mic_black_48dp.png)
  - Position: Between "Interrupt" and "Custom Prompts" buttons in title bar
  - Functionality:
    - Toggle recording: Click to start/stop audio recording
    - Uses default system microphone (no device selection required)
    - Visual feedback during recording (green background) and transcription (orange
  background)
    - Transcribed text is appended to the end of the prompt field
    - Multiple recordings can be appended sequentially


  **2. Custom Prompts Button**

  - Icon: AI icon (j-lawyer-ai.png)
  - Position: Between "Transcription" and "Reset Chat" buttons in title bar
  - Functionality:
    - Displays popup menu with user-configured chat prompts
    - Prompts are loaded from AssistantAccess.getCustomPrompts(REQUESTTYPE_CHAT)
    - Supports template placeholders ({{...}}) that are replaced with case data
    - Selected prompt replaces current prompt field content
  - Technical Implementation:
    - Placeholder replacement via TemplatesUtil
    - Integration with existing user prompt management system
    - Full exception handling and logging
    -
  **3. Added Tooltips to other buttons**