### PR TITLE
better scrolling behaviour in generic and chat assistant dialog

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantChatDialog.java
@@ -1305,19 +1305,22 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                                 int maximum = verticalBar.getMaximum();
                                 int extent = verticalBar.getVisibleAmount();
                                 boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                                int savedScrollPosition = currentValue;
 
                                 incomingMsgPanel.getMessage().setContent(resultString.toString());
                                 incomingMsgPanel.setMessage(incomingMsgPanel.getMessage(), owner);
                                 incomingMsgPanel.repaint();
                                 incomingMsgPanel.updateUI();
 
-                                // Only scroll to bottom if user was already there
-                                if (wasAtBottom) {
-                                    SwingUtilities.invokeLater(() -> {
-                                        JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                                // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                                SwingUtilities.invokeLater(() -> {
+                                    JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                                    if (wasAtBottom) {
                                         bar.setValue(bar.getMaximum());
-                                    });
-                                }
+                                    } else {
+                                        bar.setValue(savedScrollPosition);
+                                    }
+                                });
                             });
 
                             if (interrupted) {
@@ -1361,6 +1364,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                         int maximum = verticalBar.getMaximum();
                         int extent = verticalBar.getVisibleAmount();
                         boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                        int savedScrollPosition = currentValue;
 
                         Message errorMsg = new Message();
                         errorMsg.setContent(status.getStatus() + ": " + status.getStatusDetails());
@@ -1371,13 +1375,15 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                         msgPanel.setPreferredSize(maxSize);
                         pnlMessages.add(msgPanel);
 
-                        // Only scroll to bottom if user was already there
-                        if (wasAtBottom) {
-                            SwingUtilities.invokeLater(() -> {
-                                JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                        // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                        SwingUtilities.invokeLater(() -> {
+                            JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                            if (wasAtBottom) {
                                 bar.setValue(bar.getMaximum());
-                            });
-                        }
+                            } else {
+                                bar.setValue(savedScrollPosition);
+                            }
+                        });
                     } else {
                         // Check if user was at bottom BEFORE update
                         JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
@@ -1385,6 +1391,7 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                         int maximum = verticalBar.getMaximum();
                         int extent = verticalBar.getVisibleAmount();
                         boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                        int savedScrollPosition = currentValue;
 
                         StringBuilder resultString = new StringBuilder();
                         for (OutputData o : status.getResponse().getOutputData()) {
@@ -1400,13 +1407,15 @@ public class AssistantChatDialog extends javax.swing.JDialog {
                         msgPanel.repaint();
                         msgPanel.updateUI();
 
-                        // Only scroll to bottom if user was already there
-                        if (wasAtBottom) {
-                            SwingUtilities.invokeLater(() -> {
-                                JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                        // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                        SwingUtilities.invokeLater(() -> {
+                            JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                            if (wasAtBottom) {
                                 bar.setValue(bar.getMaximum());
-                            });
-                        }
+                            } else {
+                                bar.setValue(savedScrollPosition);
+                            }
+                        });
                     }
                 }
 

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantGenericDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/assistant/AssistantGenericDialog.java
@@ -1190,8 +1190,12 @@ public class AssistantGenericDialog extends javax.swing.JDialog {
                         pnlMessages.add(incomingMsgPanel);
                         incomingMsgPanel.revalidate();
                         incomingMsgPanel.repaint();
-                        JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
-                        verticalBar.setValue(verticalBar.getMaximum());
+
+                        // Smart Auto-Scroll: scroll to bottom (initial message)
+                        SwingUtilities.invokeLater(() -> {
+                            JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                            bar.setValue(bar.getMaximum());
+                        });
                     });
 
                     AiRequestStatus status = locator.lookupIntegrationServiceRemote().submitAssistantRequest(config, capability.getRequestType(), capability.getModelType(), taPrompt.getText(), fParams, inputs, null);
@@ -1211,12 +1215,28 @@ public class AssistantGenericDialog extends javax.swing.JDialog {
                             }
 
                             SwingUtilities.invokeAndWait(() -> {
+                                // Check if user was at bottom BEFORE update
+                                JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
+                                int currentValue = verticalBar.getValue();
+                                int maximum = verticalBar.getMaximum();
+                                int extent = verticalBar.getVisibleAmount();
+                                boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                                int savedScrollPosition = currentValue;
+
                                 incomingMsgPanel.getMessage().setContent(resultString.toString());
                                 incomingMsgPanel.setMessage(incomingMsgPanel.getMessage(), owner);
                                 incomingMsgPanel.repaint();
                                 incomingMsgPanel.updateUI();
-                                JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
-                                verticalBar.setValue(verticalBar.getMaximum());
+
+                                // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                                SwingUtilities.invokeLater(() -> {
+                                    JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                                    if (wasAtBottom) {
+                                        bar.setValue(bar.getMaximum());
+                                    } else {
+                                        bar.setValue(savedScrollPosition);
+                                    }
+                                });
                             });
 
                             if (interrupted) {
@@ -1240,8 +1260,6 @@ public class AssistantGenericDialog extends javax.swing.JDialog {
                     status.setStatusDetails(t.getMessage());
                     resultRef.set(status);
                     incomingMessageRef.set(incomingMsgPanel);
-                    JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
-                    verticalBar.setValue(verticalBar.getMaximum());
                 }
                 cmdSubmit.setEnabled(true);
                 cmdInterrupt.setEnabled(false);
@@ -1255,14 +1273,38 @@ public class AssistantGenericDialog extends javax.swing.JDialog {
                 result = status;
                 if (status != null) {
                     if (status.getStatus().equalsIgnoreCase("failed")) {
+                        // Check if user was at bottom BEFORE update
+                        JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
+                        int currentValue = verticalBar.getValue();
+                        int maximum = verticalBar.getMaximum();
+                        int extent = verticalBar.getVisibleAmount();
+                        boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                        int savedScrollPosition = currentValue;
+
                         AiChatMessageMarkdownPanel incomingMsgPanel = incomingMessageRef.get();
                         incomingMsgPanel.getMessage().setContent(status.getStatus() + ": " + status.getStatusDetails());
                         incomingMsgPanel.setMessage(incomingMsgPanel.getMessage(), owner);
                         incomingMsgPanel.repaint();
                         incomingMsgPanel.updateUI();
-                        JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
-                        verticalBar.setValue(verticalBar.getMaximum());
+
+                        // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                        SwingUtilities.invokeLater(() -> {
+                            JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                            if (wasAtBottom) {
+                                bar.setValue(bar.getMaximum());
+                            } else {
+                                bar.setValue(savedScrollPosition);
+                            }
+                        });
                     } else {
+                        // Check if user was at bottom BEFORE update
+                        JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
+                        int currentValue = verticalBar.getValue();
+                        int maximum = verticalBar.getMaximum();
+                        int extent = verticalBar.getVisibleAmount();
+                        boolean wasAtBottom = (currentValue + extent >= maximum - 50);
+                        int savedScrollPosition = currentValue;
+
                         StringBuilder resultString = new StringBuilder();
                         for (OutputData o : status.getResponse().getOutputData()) {
                             if (o.getType().equalsIgnoreCase(OutputData.TYPE_STRING)) {
@@ -1275,8 +1317,16 @@ public class AssistantGenericDialog extends javax.swing.JDialog {
                         msgPanel.setMessage(msgPanel.getMessage(), owner);
                         msgPanel.repaint();
                         msgPanel.updateUI();
-                        JScrollBar verticalBar = scrollMessages.getVerticalScrollBar();
-                        verticalBar.setValue(verticalBar.getMaximum());
+
+                        // Restore scroll position: scroll to bottom if at bottom, otherwise restore saved position
+                        SwingUtilities.invokeLater(() -> {
+                            JScrollBar bar = scrollMessages.getVerticalScrollBar();
+                            if (wasAtBottom) {
+                                bar.setValue(bar.getMaximum());
+                            } else {
+                                bar.setValue(savedScrollPosition);
+                            }
+                        });
                     }
                 }
 


### PR DESCRIPTION
Ich habe auch den AssistantChatDialog noch einmal angefasst und das Verhalten optimiert. 

Im letzten Commit (der dieses Problem betraf) sprang der Fokus noch auf den Anfang der Ingo-Nachricht, wenn eigentlich frei gescrollt werden sollte, folgte aber schon dem Polling bei jedem neuen Chunk, der generiert wurde, sofern der Scrollbalken „unten“ war.

Der Scrollbalken und der Aufbau der Antwort von Ingo sind nun komplett voneinander entkoppelt, sodass ein wirklich freies Scrollen während des „Ladens“ der Antwort von Ingo möglich ist. 

Ist der Scrollbalken am unteren Ende des Fensters, so bleibt der Scrollbalken immer unten, sodass der Anwender den aktuellen Stand der Antwort immer sehen kann. 

Ich empfinde diese Änderung als sehr komfortabel bei längeren Antworten. 

#3132
#3138