### PR TITLE
REST API: backup configuration endpoints

### DIFF
--- a/j-lawyer-server/j-lawyer-io/build.xml
+++ b/j-lawyer-server/j-lawyer-io/build.xml
@@ -84,6 +84,7 @@
                 <pathelement location="../../j-lawyer-server-entities/dist/j-lawyer-server-entities.jar"/>
                 <pathelement location="../../j-lawyer-server-api/dist/j-lawyer-server-api.jar"/>
                 <pathelement location="../../j-lawyer-server-common/dist/j-lawyer-server-common.jar"/>
+                <pathelement location="../j-lawyer-server-ejb/dist/j-lawyer-server-ejb.jar"/>
                 <pathelement path="${java.class.path}"/>
             </classpath>
         </java>

--- a/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointLocalV7.java
+++ b/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointLocalV7.java
@@ -665,6 +665,7 @@ package org.jlawyer.io.rest.v7;
 
 import javax.ejb.Local;
 import javax.ws.rs.core.Response;
+import org.jlawyer.io.rest.v7.pojo.RestfulBackupConfigurationV7;
 import org.jlawyer.io.rest.v7.pojo.RestfulCredentials;
 
 /**
@@ -679,5 +680,11 @@ public interface AdministrationEndpointLocalV7 {
     Response getJobStatus(String jobId);
     
     public Response listJobs();
+    
+    Response getBackupConfiguration();
+    
+    Response updateBackupConfiguration(RestfulBackupConfigurationV7 configuration);
+    
+    Response deleteBackupData();
     
 }

--- a/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointV7.java
+++ b/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointV7.java
@@ -663,10 +663,14 @@ For more information on this, and how to apply and follow the GNU AGPL, see
  */
 package org.jlawyer.io.rest.v7;
 
+import com.jdimension.jlawyer.persistence.ServerSettingsBean;
 import com.jdimension.jlawyer.persistence.utils.StringGenerator;
 import com.jdimension.jlawyer.pojo.JobStatus;
+import com.jdimension.jlawyer.server.services.settings.ServerSettingsKeys;
 import com.jdimension.jlawyer.services.SingletonServiceLocal;
+import com.jdimension.jlawyer.services.SystemManagementLocal;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -674,19 +678,24 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import javax.annotation.security.RolesAllowed;
 import javax.ejb.Stateless;
 import javax.naming.InitialContext;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.jboss.logging.Logger;
+import org.jlawyer.io.rest.v7.pojo.RestfulBackupConfigurationV7;
 import org.jlawyer.io.rest.v7.pojo.RestfulCredentials;
 import org.jlawyer.io.rest.v7.pojo.RestfulJobStatusV7;
+import org.jlawyer.io.rest.v7.pojo.RestfulStatusResponseV7;
 
 /**
  *
@@ -700,6 +709,7 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
 
     private static final Logger log = Logger.getLogger(AdministrationEndpointV7.class.getName());
     private static final String LOOKUP_SINGLETON = "java:global/j-lawyer-server/j-lawyer-server-ejb/SingletonService!com.jdimension.jlawyer.services.SingletonServiceLocal";
+    private static final String LOOKUP_SYSMAN = "java:global/j-lawyer-server/j-lawyer-server-ejb/SystemManagement!com.jdimension.jlawyer.services.SystemManagementLocal";
 
     /**
      * Triggers a backup run and returns its status. The job ID may be used to
@@ -829,6 +839,278 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
             return res;
         }
 
+    }
+
+    /**
+     * Returns the current backup configuration including scheduling,
+     * database connection, encryption, directories, and notification
+     * settings. Passwords are never included in the response (write-only).
+     *
+     * @return backup configuration
+     * @response 401 User not authorized
+     * @response 403 User not authenticated
+     */
+    @Override
+    @Path("/backup/configuration")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @RolesAllowed({"loginRole"})
+    public Response getBackupConfiguration() {
+
+        try {
+
+            InitialContext ic = new InitialContext();
+            SystemManagementLocal sysman = (SystemManagementLocal) ic.lookup(LOOKUP_SYSMAN);
+
+            RestfulBackupConfigurationV7 config = new RestfulBackupConfigurationV7();
+
+            // scheduling
+            config.setBackupMode(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_MODE, "off"));
+            config.setHour(getSettingInt(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_HOUR, 22));
+            config.setMonday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_MONDAY));
+            config.setTuesday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_TUESDAY));
+            config.setWednesday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_WEDNESDAY));
+            config.setThursday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_THURSDAY));
+            config.setFriday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_FRIDAY));
+            config.setSaturday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_SATURDAY));
+            config.setSunday(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_SUNDAY));
+
+            // database (passwords excluded)
+            config.setDbHost(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_DBHOST, "localhost"));
+            config.setDbPort(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_DBPORT, "3306"));
+            config.setDbName(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_DBNAME, "jlawyerdb"));
+            config.setDbUser(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_DBUSER, "root"));
+            config.setDbPassword(null);
+
+            // encryption (password excluded, only flag)
+            String encPwd = getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_ENCRYPTPWD, "");
+            config.setEncryptionEnabled(encPwd != null && !encPwd.isEmpty());
+            config.setEncryptionPassword(null);
+
+            // directories
+            config.setBackupDirectory(sysman.getBackupDirectory());
+            config.setSyncTarget(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, ""));
+            config.setExportTarget(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_EXPORTTARGET, ""));
+
+            // notifications
+            config.setNotifyOnSuccess(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_MONITOR_NOTIFY_BACKUPSUCCESS));
+            config.setNotifyOnFailure(getSettingBoolean(sysman, ServerSettingsKeys.SERVERCONF_MONITOR_NOTIFY_BACKUPFAILURE));
+
+            return Response.ok(config).build();
+
+        } catch (Exception ex) {
+            log.error("Could not get backup configuration", ex);
+            return Response.serverError().build();
+        }
+
+    }
+
+    /**
+     * Updates the backup configuration. For string fields, null means
+     * "do not change"; boolean and int fields are always applied.
+     * Validates backupMode ("on"/"off"), hour (0-23), dbPort (1-65535),
+     * and that backupDirectory / exportTarget exist on the server.
+     * Changing the encryptionPassword automatically deletes all existing
+     * backup data. Returns the full updated configuration on success.
+     *
+     * @param configuration the backup configuration to apply
+     * @return the updated backup configuration
+     * @response 401 User not authorized
+     * @response 403 User not authenticated
+     * @response 400 Validation error (e.g. invalid port, non-existent directory)
+     */
+    @Override
+    @Path("/backup/configuration")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Consumes(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @RolesAllowed({"sysAdminRole"})
+    public Response updateBackupConfiguration(RestfulBackupConfigurationV7 configuration) {
+
+        try {
+
+            InitialContext ic = new InitialContext();
+            SystemManagementLocal sysman = (SystemManagementLocal) ic.lookup(LOOKUP_SYSMAN);
+
+            // validate port
+            if (configuration.getDbPort() != null) {
+                try {
+                    int port = Integer.parseInt(configuration.getDbPort());
+                    if (port < 1 || port > 65535) {
+                        return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("dbPort must be between 1 and 65535")).build();
+                    }
+                } catch (NumberFormatException nfe) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("dbPort must be a valid integer")).build();
+                }
+            }
+
+            // validate hour
+            if (configuration.getHour() < 0 || configuration.getHour() > 23) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("hour must be between 0 and 23")).build();
+            }
+
+            // validate backup directory
+            if (configuration.getBackupDirectory() != null && !configuration.getBackupDirectory().trim().isEmpty()) {
+                File backupDirFile = new File(configuration.getBackupDirectory().trim());
+                if (!backupDirFile.exists()) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Backup directory does not exist: " + configuration.getBackupDirectory())).build();
+                }
+                if (!backupDirFile.isDirectory()) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Backup directory path is not a directory: " + configuration.getBackupDirectory())).build();
+                }
+                if (!backupDirFile.canWrite()) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Backup directory is not writable: " + configuration.getBackupDirectory())).build();
+                }
+            }
+
+            // validate export target
+            if (configuration.getExportTarget() != null && !configuration.getExportTarget().trim().isEmpty()) {
+                File exportDirFile = new File(configuration.getExportTarget().trim());
+                if (!exportDirFile.exists() || !exportDirFile.isDirectory()) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Export target directory does not exist or is not a directory: " + configuration.getExportTarget())).build();
+                }
+            }
+
+            // validate backupMode
+            if (configuration.getBackupMode() != null) {
+                String mode = configuration.getBackupMode().trim().toLowerCase();
+                if (!"on".equals(mode) && !"off".equals(mode)) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("backupMode must be 'on' or 'off'")).build();
+                }
+            }
+
+            // apply settings
+            if (configuration.getBackupMode() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_MODE, configuration.getBackupMode().trim().toLowerCase());
+            }
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_HOUR, String.valueOf(configuration.getHour()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_MONDAY, String.valueOf(configuration.isMonday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_TUESDAY, String.valueOf(configuration.isTuesday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_WEDNESDAY, String.valueOf(configuration.isWednesday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_THURSDAY, String.valueOf(configuration.isThursday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_FRIDAY, String.valueOf(configuration.isFriday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_SATURDAY, String.valueOf(configuration.isSaturday()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_SUNDAY, String.valueOf(configuration.isSunday()));
+
+            // database settings
+            if (configuration.getDbHost() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DBHOST, configuration.getDbHost());
+            }
+            if (configuration.getDbPort() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DBPORT, configuration.getDbPort());
+            }
+            if (configuration.getDbName() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DBNAME, configuration.getDbName());
+            }
+            if (configuration.getDbUser() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DBUSER, configuration.getDbUser());
+            }
+            if (configuration.getDbPassword() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DBPWD, configuration.getDbPassword());
+            }
+
+            // encryption password - if changed, clear existing backups
+            if (configuration.getEncryptionPassword() != null) {
+                String currentEncPwd = getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_ENCRYPTPWD, "");
+                if (!configuration.getEncryptionPassword().equals(currentEncPwd)) {
+                    sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_ENCRYPTPWD, configuration.getEncryptionPassword());
+                    // clearCurrentBackup is @Asynchronous, runs in background
+                    sysman.clearCurrentBackup();
+                }
+            }
+
+            // directories
+            if (configuration.getBackupDirectory() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DIRECTORY, configuration.getBackupDirectory().trim());
+            }
+            if (configuration.getSyncTarget() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, configuration.getSyncTarget());
+            }
+            if (configuration.getExportTarget() != null) {
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_EXPORTTARGET, configuration.getExportTarget());
+            }
+
+            // notifications
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_MONITOR_NOTIFY_BACKUPSUCCESS, String.valueOf(configuration.isNotifyOnSuccess()));
+            sysman.setSetting(ServerSettingsKeys.SERVERCONF_MONITOR_NOTIFY_BACKUPFAILURE, String.valueOf(configuration.isNotifyOnFailure()));
+
+            // return current state
+            return this.getBackupConfiguration();
+
+        } catch (Exception ex) {
+            log.error("Could not update backup configuration", ex);
+            return Response.serverError().build();
+        }
+
+    }
+
+    /**
+     * Deletes all existing backup data in the configured backup directory on
+     * the server. Runs asynchronously - the response confirms initiation,
+     * not completion. Same operation that is triggered when the encryption
+     * password is changed via PUT. Does not affect the HTML export directory
+     * or the sync target.
+     *
+     * @return status response
+     * @response 401 User not authorized
+     * @response 403 User not authenticated
+     */
+    @Override
+    @Path("/backup/data")
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @RolesAllowed({"sysAdminRole"})
+    public Response deleteBackupData() {
+
+        try {
+
+            InitialContext ic = new InitialContext();
+            SystemManagementLocal sysman = (SystemManagementLocal) ic.lookup(LOOKUP_SYSMAN);
+
+            // clearCurrentBackup is @Asynchronous
+            sysman.clearCurrentBackup();
+
+            RestfulStatusResponseV7 status = new RestfulStatusResponseV7();
+            status.setStatus(RestfulStatusResponseV7.STATUS_OK);
+            status.setMessage("Backup data deletion initiated. The operation runs asynchronously in the background.");
+            return Response.ok(status).build();
+
+        } catch (Exception ex) {
+            log.error("Could not delete backup data", ex);
+            return Response.serverError().build();
+        }
+
+    }
+
+    // --- helper methods ---
+
+    private String getSettingValue(SystemManagementLocal sysman, String key, String defaultValue) {
+        ServerSettingsBean bean = sysman.getSetting(key);
+        if (bean != null && bean.getSettingValue() != null) {
+            return bean.getSettingValue();
+        }
+        return defaultValue;
+    }
+
+    private boolean getSettingBoolean(SystemManagementLocal sysman, String key) {
+        String value = getSettingValue(sysman, key, "false");
+        return "true".equalsIgnoreCase(value);
+    }
+
+    private int getSettingInt(SystemManagementLocal sysman, String key, int defaultValue) {
+        String value = getSettingValue(sysman, key, String.valueOf(defaultValue));
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private RestfulStatusResponseV7 errorResponse(String message) {
+        RestfulStatusResponseV7 r = new RestfulStatusResponseV7();
+        r.setStatus(RestfulStatusResponseV7.STATUS_ERROR);
+        r.setMessage(message);
+        return r;
     }
 
 }

--- a/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointV7.java
+++ b/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/AdministrationEndpointV7.java
@@ -669,6 +669,7 @@ import com.jdimension.jlawyer.pojo.JobStatus;
 import com.jdimension.jlawyer.server.services.settings.ServerSettingsKeys;
 import com.jdimension.jlawyer.services.SingletonServiceLocal;
 import com.jdimension.jlawyer.services.SystemManagementLocal;
+import com.jdimension.jlawyer.storage.VirtualFile;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -889,7 +890,7 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
 
             // directories
             config.setBackupDirectory(sysman.getBackupDirectory());
-            config.setSyncTarget(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, ""));
+            config.setSyncTarget(sanitizeSyncTargetForResponse(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, "")));
             config.setExportTarget(getSettingValue(sysman, ServerSettingsKeys.SERVERCONF_BACKUP_EXPORTTARGET, ""));
 
             // notifications
@@ -909,7 +910,8 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
      * Updates the backup configuration. For string fields, null means
      * "do not change"; boolean and int fields are always applied.
      * Validates backupMode ("on"/"off"), hour (0-23), dbPort (1-65535),
-     * and that backupDirectory / exportTarget exist on the server.
+     * and that backupDirectory / exportTarget exist on the server, and
+     * syncTarget is reachable and writable.
      * Changing the encryptionPassword automatically deletes all existing
      * backup data. Returns the full updated configuration on success.
      *
@@ -971,6 +973,31 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
                 }
             }
 
+            // validate sync target
+            if (configuration.getSyncTarget() != null && !configuration.getSyncTarget().trim().isEmpty()) {
+                VirtualFile syncTarget = null;
+                try {
+                    String syncTargetLocation = configuration.getSyncTarget().trim();
+                    syncTarget = VirtualFile.getFile(syncTargetLocation);
+                    if (!syncTarget.exists() || !syncTarget.isDirectory()) {
+                        return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Sync target must point to an existing directory: " + sanitizeSyncTargetForResponse(syncTargetLocation))).build();
+                    }
+                    if (!syncTarget.isReadable() || !syncTarget.isWritable()) {
+                        return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Sync target is not readable and writable: " + sanitizeSyncTargetForResponse(syncTargetLocation))).build();
+                    }
+                } catch (Exception ex) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse("Sync target is not reachable or invalid")).build();
+                } finally {
+                    if (syncTarget != null) {
+                        try {
+                            syncTarget.close();
+                        } catch (Exception ex) {
+                            log.warn("Could not close sync target", ex);
+                        }
+                    }
+                }
+            }
+
             // validate backupMode
             if (configuration.getBackupMode() != null) {
                 String mode = configuration.getBackupMode().trim().toLowerCase();
@@ -1024,7 +1051,7 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
                 sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_DIRECTORY, configuration.getBackupDirectory().trim());
             }
             if (configuration.getSyncTarget() != null) {
-                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, configuration.getSyncTarget());
+                sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_SYNCTARGET, configuration.getSyncTarget().trim());
             }
             if (configuration.getExportTarget() != null) {
                 sysman.setSetting(ServerSettingsKeys.SERVERCONF_BACKUP_EXPORTTARGET, configuration.getExportTarget());
@@ -1111,6 +1138,34 @@ public class AdministrationEndpointV7 implements AdministrationEndpointLocalV7 {
         r.setStatus(RestfulStatusResponseV7.STATUS_ERROR);
         r.setMessage(message);
         return r;
+    }
+
+    private String sanitizeSyncTargetForResponse(String syncTarget) {
+        if (syncTarget == null || syncTarget.trim().isEmpty()) {
+            return syncTarget;
+        }
+
+        String trimmed = syncTarget.trim();
+        int protocolSeparatorIndex = trimmed.indexOf("://");
+        if (protocolSeparatorIndex < 0) {
+            return trimmed;
+        }
+
+        String prefix = trimmed.substring(0, protocolSeparatorIndex + 3);
+        String remainder = trimmed.substring(protocolSeparatorIndex + 3);
+        int atIndex = remainder.indexOf('@');
+        if (atIndex < 0) {
+            return trimmed;
+        }
+
+        String userInfo = remainder.substring(0, atIndex);
+        int colonIndex = userInfo.indexOf(':');
+        if (colonIndex < 0) {
+            return trimmed;
+        }
+
+        String sanitizedUserInfo = userInfo.substring(0, colonIndex) + ":***";
+        return prefix + sanitizedUserInfo + remainder.substring(atIndex);
     }
 
 }

--- a/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/pojo/RestfulBackupConfigurationV7.java
+++ b/j-lawyer-server/j-lawyer-io/src/java/org/jlawyer/io/rest/v7/pojo/RestfulBackupConfigurationV7.java
@@ -661,143 +661,384 @@ if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
  */
-package com.jdimension.jlawyer.server.services.settings;
+package org.jlawyer.io.rest.v7.pojo;
 
 /**
+ * DTO for backup configuration settings exposed via the REST API.
  *
- * @author jens
+ * Passwords (dbPassword, encryptionPassword) are write-only: GET responses
+ * always return null for these fields. In PUT requests, null means "do not
+ * change the current password".
+ *
+ * Scheduling:
+ *   backupMode - "on" or "off"; controls whether scheduled backups are active.
+ *   hour - hour of day for scheduled backups (0-23, default 22).
+ *   monday..sunday - which weekdays the scheduled backup should run.
+ *
+ * Database:
+ *   dbHost - hostname of the database server (default "localhost").
+ *   dbPort - TCP port as string, valid range 1-65535 (default "3306").
+ *   dbName - database / schema name (default "jlawyerdb").
+ *   dbUser - database user (default "root").
+ *   dbPassword - write-only; never returned in GET, null in PUT leaves unchanged.
+ *
+ * Encryption:
+ *   encryptionEnabled - read-only flag, true if an encryption password is set.
+ *   encryptionPassword - write-only; never returned in GET, null in PUT leaves
+ *     unchanged. Changing this value triggers deletion of all existing backup data.
+ *
+ * Directories:
+ *   backupDirectory - absolute server-side path where backup data is stored.
+ *     Must exist and be writable. Defaults to parent-of-basedirectory/backups/.
+ *   exportTarget - absolute server-side path for the HTML export. When non-empty,
+ *     every backup run also creates a browser-viewable HTML export of all cases
+ *     (incremental, only modified cases are re-exported). Empty string disables.
+ *   syncTarget - remote sync URL for FTP/SFTP/SMB
+ *     (e.g. "sftp://user:pass@host/path"). Empty string disables.
+ *
+ * Notifications:
+ *   notifyOnSuccess - send email when backup completes successfully.
+ *   notifyOnFailure - send email when backup fails.
+ *
+ * @author max
  */
-public class ServerSettingsKeys {
-    
-    public static final String PROFILE_COMPANYNAME="profile.company.name";
-    public static final String PROFILE_COMPANYSTREET="profile.company.street";
-    public static final String PROFILE_COMPANYSTREET2="profile.company.street2";
-    public static final String PROFILE_COMPANYZIP="profile.company.zip";
-    public static final String PROFILE_COMPANYCITY="profile.company.city";
-    public static final String PROFILE_COMPANYCOUNTRY="profile.company.country";
-    
-    public static final String PROFILE_COMPANYPHONE="profile.company.phone";
-    public static final String PROFILE_COMPANYFAX="profile.company.fax";
-    public static final String PROFILE_COMPANYMOBILE="profile.company.mobile";
-    
-    public static final String PROFILE_COMPANYEMAIL="profile.company.email";
-    public static final String PROFILE_COMPANYWWW="profile.company.www";
-    
-    public static final String PROFILE_COMPANYTAXID="profile.company.taxid";
-    public static final String PROFILE_COMPANYUSTID="profile.company.ustid";
-    public static final String PROFILE_COMPANYBANK="profile.company.bank";
-    public static final String PROFILE_COMPANYBANKCODE="profile.company.bankcode";
-    public static final String PROFILE_COMPANYACCOUNTNO="profile.company.accountno";
-    
-    public static final String PROFILE_COMPANYBANK_AK="profile.company.ak.bank";
-    public static final String PROFILE_COMPANYBANKCODE_AK="profile.company.ak.bankcode";
-    public static final String PROFILE_COMPANYACCOUNTNO_AK="profile.company.ak.accountno";
-    
-    public static final String SERVERCONF_BEAMODE="jlawyer.server.bea.beamode";
-    public static final String SERVERCONF_BEAENDPOINT="jlawyer.server.bea.beaendpoint";
-    public static final String SERVERCONF_BEAENABLEDVERSIONS="jlawyer.global.bea.enabledversions";
-    
-    public static final String SERVERCONF_BACKUP_MODE="jlawyer.server.backup.backupmode";
-    public static final String SERVERCONF_BACKUP_DBUSER="jlawyer.server.backup.dbuser";
-    public static final String SERVERCONF_BACKUP_DBPWD="jlawyer.server.backup.dbpassword";
-    public static final String SERVERCONF_BACKUP_DBPORT="jlawyer.server.backup.dbport";
-    public static final String SERVERCONF_BACKUP_DBHOST="jlawyer.server.backup.dbhost";
-    public static final String SERVERCONF_BACKUP_DBNAME="jlawyer.server.backup.dbname";
-    public static final String SERVERCONF_BACKUP_HOUR="jlawyer.server.backup.hour";
-    public static final String SERVERCONF_BACKUP_MONDAY="jlawyer.server.backup.monday";
-    public static final String SERVERCONF_BACKUP_TUESDAY="jlawyer.server.backup.tuesday";
-    public static final String SERVERCONF_BACKUP_WEDNESDAY="jlawyer.server.backup.wednesday";
-    public static final String SERVERCONF_BACKUP_THURSDAY="jlawyer.server.backup.thursday";
-    public static final String SERVERCONF_BACKUP_FRIDAY="jlawyer.server.backup.friday";
-    public static final String SERVERCONF_BACKUP_SATURDAY="jlawyer.server.backup.saturday";
-    public static final String SERVERCONF_BACKUP_SUNDAY="jlawyer.server.backup.sunday";
-    public static final String SERVERCONF_BACKUP_ENCRYPTPWD="jlawyer.server.backup.encryptionpwd";
-    
-    public static final String SERVERCONF_BACKUP_SYNCTARGET="jlawyer.server.backup.synctarget";
-    public static final String SERVERCONF_BACKUP_EXPORTTARGET="jlawyer.server.backup.exporttarget";
-    public static final String SERVERCONF_BACKUP_DIRECTORY="jlawyer.server.backup.directory";
-    
-    public static final String SERVERCONF_REPLICATION_ISTARGET="jlawyer.server.replication.istarget";
-    
-    public static final String SERVERCONF_MONITOR_CPUWARN="jlawyer.server.monitor.cpuwarn";
-    public static final String SERVERCONF_MONITOR_CPUERROR="jlawyer.server.monitor.cpuerror";
-    public static final String SERVERCONF_MONITOR_MEMWARN="jlawyer.server.monitor.memwarn";
-    public static final String SERVERCONF_MONITOR_MEMERROR="jlawyer.server.monitor.memerror";
-    public static final String SERVERCONF_MONITOR_DISKWARN="jlawyer.server.monitor.diskwarn";
-    public static final String SERVERCONF_MONITOR_DISKERROR="jlawyer.server.monitor.diskerror";
-    public static final String SERVERCONF_MONITOR_VMWARN="jlawyer.server.monitor.vmwarn";
-    public static final String SERVERCONF_MONITOR_VMERROR="jlawyer.server.monitor.vmerror";
-    public static final String SERVERCONF_MONITOR_NOTIFY="jlawyer.server.monitor.notify";
-    public static final String SERVERCONF_MONITOR_NOTIFY_BACKUPSUCCESS="jlawyer.server.monitor.notify.backupsuccess";
-    public static final String SERVERCONF_MONITOR_NOTIFY_BACKUPFAILURE="jlawyer.server.monitor.notify.backupfailure";
-    public static final String SERVERCONF_MONITOR_SMTPSERVER="jlawyer.server.monitor.smtpserver";
-    public static final String SERVERCONF_MONITOR_SMTPPORT="jlawyer.server.monitor.smtpport";
-    public static final String SERVERCONF_MONITOR_SMTPUSER="jlawyer.server.monitor.smtpuser";
-    public static final String SERVERCONF_MONITOR_SMTPPASSWORD="jlawyer.server.monitor.smtppwd";
-    public static final String SERVERCONF_MONITOR_SMTPSENDERNAME="jlawyer.server.monitor.smtpsendername";
-    public static final String SERVERCONF_MONITOR_SMTPTO="jlawyer.server.monitor.smtpto";
-    public static final String SERVERCONF_MONITOR_SMTPSSL="jlawyer.server.monitor.smtpssl";
-    public static final String SERVERCONF_MONITOR_SMTPSTARTTLS="jlawyer.server.monitor.smtpstarttls";
-    
-    public static final String SERVERCONF_MONITOR_ENABLED_CPU="jlawyer.server.monitor.enabled.cpu";
-    public static final String SERVERCONF_MONITOR_ENABLED_RAM="jlawyer.server.monitor.enabled.ram";
-    public static final String SERVERCONF_MONITOR_ENABLED_DISK="jlawyer.server.monitor.enabled.disk";
-    public static final String SERVERCONF_MONITOR_ENABLED_JAVA="jlawyer.server.monitor.enabled.java";
-    
-    public static final String SERVERCONF_CASENUMBERING_PATTERN="jlawyer.server.numbering.pattern";
-    public static final String SERVERCONF_CASENUMBERING_STARTFROM="jlawyer.server.numbering.startfrom";
-    public static final String SERVERCONF_CASENUMBERING_INCREMENT="jlawyer.server.numbering.increment";
-    
-    public static final String SERVERCONF_CASENUMBERING_EXT_ENABLED="jlawyer.server.numbering.ext.enabled";
-    public static final String SERVERCONF_CASENUMBERING_EXT_DIVIDER_MAIN="jlawyer.server.numbering.ext.divider.main";
-    public static final String SERVERCONF_CASENUMBERING_EXT_DIVIDER_EXT="jlawyer.server.numbering.ext.divider.ext";
-    public static final String SERVERCONF_CASENUMBERING_EXT_PREFIX_ENABLED="jlawyer.server.numbering.ext.prefix.enabled";
-    public static final String SERVERCONF_CASENUMBERING_EXT_PREFIX="jlawyer.server.numbering.ext.prefix";
-    public static final String SERVERCONF_CASENUMBERING_EXT_SUFFIX_ENABLED="jlawyer.server.numbering.ext.suffix.enabled";
-    public static final String SERVERCONF_CASENUMBERING_EXT_SUFFIX="jlawyer.server.numbering.ext.suffix";
-    public static final String SERVERCONF_CASENUMBERING_EXT_GROUP_ENABLED="jlawyer.server.numbering.ext.group.enabled";
-    public static final String SERVERCONF_CASENUMBERING_EXT_LAWYER_ENABLED="jlawyer.server.numbering.ext.lawyer.enabled";
-    
-    public static final String SERVERCONF_SCANNER_SERVERDIR="jlawyer.server.observe.directory";
-    public static final String SERVERCONF_SCANNER_OCRCMD="jlawyer.server.observe.ocrcmd";
-    
-    public static final String DATA_CUSTOMFIELD_ADDRESS_PREFIX="data.customfields.address.";
-    public static final String DATA_CUSTOMFIELD_ARCHIVEFILE_PREFIX="data.customfields.archivefile.";
-    public static final String DATA_CUSTOMFIELD_ARCHIVEFILE_INVOLVED_PREFIX="data.customfields.archivefile.involved.";
-    
-    public static final String SERVERCONF_DOCUMENTS_WAITFOR_MAC="jlawyer.server.documents.waitforprocess.mac";
-    
-    public static final String SERVERCONF_DOCUMENTS_BIN_RETENTIONDAYS="jlawyer.server.documents.bin.retentiondays";
-    
-    public static final String SERVERCONF_SECURITY_FORCE_PASSWORDCOMPLEXITY="jlawyer.server.security.forcepasswordcomplexity";
-    
-    public static final String SERVERCONF_FINANCE_GIROCODEPX="jlawyer.server.finance.girocodepx";
-    
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_ENABLED="jlawyer.server.cloudsync.addressbook.enabled";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_BIRTHDAYSYNC="jlawyer.server.cloudsync.addressbook.birthdaysync";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_HOST="jlawyer.server.cloudsync.addressbook.host";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_PORT="jlawyer.server.cloudsync.addressbook.port";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_SSL="jlawyer.server.cloudsync.addressbook.ssl";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_PATH="jlawyer.server.cloudsync.addressbook.path";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_USER="jlawyer.server.cloudsync.addressbook.user";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_PWD="jlawyer.server.cloudsync.addressbook.pwd";
-    public static final String SERVERCONF_CLOUDSYNC_ADDRESSBOOK_HREF="jlawyer.server.cloudsync.addressbook.href";
-    
-    public static final String SERVERCONF_CLOUDSYNC_CALENDAR_FULLSYNC="jlawyer.server.cloudsync.calendar.fullsync";
-    
-    public static final String SERVERCONF_CALENDAR_CONFLICTCHECK="jlawyer.server.calendar.conflictcheck";
-    
-    public static final String SERVERCONF_USAGELIMIT_MAXUSERS="jlawyer.server.usagelimit.maxusers";
-    
-    public static final String SERVERCONF_TIMESHEET_PARALLELLOGS_WARNING="jlawyer.server.timesheets.parallellogswarning";
-    // can have values "minutes", "hours", "reject"
-    public static final String SERVERCONF_TIMESHEET_NUMERICINPUT="jlawyer.server.timesheets.numericinput";
-    
-    public static final String SERVERCONF_INSTANTMESSAGING_POLLING_ENABLED="jlawyer.server.instantmessaging.polling.enabled";
-    
-    public static final String SERVERCONF_INSTALLATION_ID="jlawyer.server.installation.id";
-    public static final String SERVERCONF_EPOSTVENDORID_ENCRYPTED="jlawyer.server.epost.vendorid";
-    
-    public static final String SERVERCONF_STIRLINGPDF_ENDPOINT="jlawyer.server.stirlingpdf.endpoint";
-    
+public class RestfulBackupConfigurationV7 {
+
+    // scheduling
+    private String backupMode = null;
+    private int hour = 22;
+    private boolean monday = false;
+    private boolean tuesday = false;
+    private boolean wednesday = false;
+    private boolean thursday = false;
+    private boolean friday = false;
+    private boolean saturday = false;
+    private boolean sunday = false;
+
+    // database
+    private String dbHost = null;
+    private String dbPort = null;
+    private String dbName = null;
+    private String dbUser = null;
+    private String dbPassword = null;
+
+    // encryption
+    private String encryptionPassword = null;
+    private boolean encryptionEnabled = false;
+
+    // directories
+    private String backupDirectory = null;
+    private String syncTarget = null;
+    private String exportTarget = null;
+
+    // notifications
+    private boolean notifyOnSuccess = false;
+    private boolean notifyOnFailure = false;
+
+    public RestfulBackupConfigurationV7() {
+
+    }
+
+    /**
+     * @return "on" or "off" indicating whether scheduled backups are active
+     */
+    public String getBackupMode() {
+        return backupMode;
+    }
+
+    /**
+     * @param backupMode the backupMode to set
+     */
+    public void setBackupMode(String backupMode) {
+        this.backupMode = backupMode;
+    }
+
+    /**
+     * @return hour of day for scheduled backups (0-23)
+     */
+    public int getHour() {
+        return hour;
+    }
+
+    /**
+     * @param hour the hour to set
+     */
+    public void setHour(int hour) {
+        this.hour = hour;
+    }
+
+    /**
+     * @return the monday
+     */
+    public boolean isMonday() {
+        return monday;
+    }
+
+    /**
+     * @param monday the monday to set
+     */
+    public void setMonday(boolean monday) {
+        this.monday = monday;
+    }
+
+    /**
+     * @return the tuesday
+     */
+    public boolean isTuesday() {
+        return tuesday;
+    }
+
+    /**
+     * @param tuesday the tuesday to set
+     */
+    public void setTuesday(boolean tuesday) {
+        this.tuesday = tuesday;
+    }
+
+    /**
+     * @return the wednesday
+     */
+    public boolean isWednesday() {
+        return wednesday;
+    }
+
+    /**
+     * @param wednesday the wednesday to set
+     */
+    public void setWednesday(boolean wednesday) {
+        this.wednesday = wednesday;
+    }
+
+    /**
+     * @return the thursday
+     */
+    public boolean isThursday() {
+        return thursday;
+    }
+
+    /**
+     * @param thursday the thursday to set
+     */
+    public void setThursday(boolean thursday) {
+        this.thursday = thursday;
+    }
+
+    /**
+     * @return the friday
+     */
+    public boolean isFriday() {
+        return friday;
+    }
+
+    /**
+     * @param friday the friday to set
+     */
+    public void setFriday(boolean friday) {
+        this.friday = friday;
+    }
+
+    /**
+     * @return the saturday
+     */
+    public boolean isSaturday() {
+        return saturday;
+    }
+
+    /**
+     * @param saturday the saturday to set
+     */
+    public void setSaturday(boolean saturday) {
+        this.saturday = saturday;
+    }
+
+    /**
+     * @return the sunday
+     */
+    public boolean isSunday() {
+        return sunday;
+    }
+
+    /**
+     * @param sunday the sunday to set
+     */
+    public void setSunday(boolean sunday) {
+        this.sunday = sunday;
+    }
+
+    /**
+     * @return hostname of the database server (default "localhost")
+     */
+    public String getDbHost() {
+        return dbHost;
+    }
+
+    /**
+     * @param dbHost the dbHost to set
+     */
+    public void setDbHost(String dbHost) {
+        this.dbHost = dbHost;
+    }
+
+    /**
+     * @return TCP port of the database server as string, 1-65535 (default "3306")
+     */
+    public String getDbPort() {
+        return dbPort;
+    }
+
+    /**
+     * @param dbPort the dbPort to set
+     */
+    public void setDbPort(String dbPort) {
+        this.dbPort = dbPort;
+    }
+
+    /**
+     * @return database / schema name (default "jlawyerdb")
+     */
+    public String getDbName() {
+        return dbName;
+    }
+
+    /**
+     * @param dbName the dbName to set
+     */
+    public void setDbName(String dbName) {
+        this.dbName = dbName;
+    }
+
+    /**
+     * @return database user (default "root")
+     */
+    public String getDbUser() {
+        return dbUser;
+    }
+
+    /**
+     * @param dbUser the dbUser to set
+     */
+    public void setDbUser(String dbUser) {
+        this.dbUser = dbUser;
+    }
+
+    /**
+     * @return always null in GET responses (write-only); in PUT, set to
+     *         change the database password, null to leave unchanged
+     */
+    public String getDbPassword() {
+        return dbPassword;
+    }
+
+    /**
+     * @param dbPassword the dbPassword to set
+     */
+    public void setDbPassword(String dbPassword) {
+        this.dbPassword = dbPassword;
+    }
+
+    /**
+     * @return always null in GET responses (write-only); in PUT, set to
+     *         change the encryption password, null to leave unchanged.
+     *         Changing this value triggers deletion of all existing backup data
+     */
+    public String getEncryptionPassword() {
+        return encryptionPassword;
+    }
+
+    /**
+     * @param encryptionPassword the encryptionPassword to set
+     */
+    public void setEncryptionPassword(String encryptionPassword) {
+        this.encryptionPassword = encryptionPassword;
+    }
+
+    /**
+     * @return true if an encryption password is currently configured
+     *         (read-only, ignored in PUT)
+     */
+    public boolean isEncryptionEnabled() {
+        return encryptionEnabled;
+    }
+
+    /**
+     * @param encryptionEnabled the encryptionEnabled to set
+     */
+    public void setEncryptionEnabled(boolean encryptionEnabled) {
+        this.encryptionEnabled = encryptionEnabled;
+    }
+
+    /**
+     * @return absolute server-side path where backup data is stored; defaults
+     *         to parent-of-basedirectory/backups/ when not configured
+     */
+    public String getBackupDirectory() {
+        return backupDirectory;
+    }
+
+    /**
+     * @param backupDirectory the backupDirectory to set
+     */
+    public void setBackupDirectory(String backupDirectory) {
+        this.backupDirectory = backupDirectory;
+    }
+
+    /**
+     * @return remote sync URL (e.g. "sftp://user:pass@host/path") for
+     *         synchronizing the backup to external storage, empty means disabled
+     */
+    public String getSyncTarget() {
+        return syncTarget;
+    }
+
+    /**
+     * @param syncTarget the syncTarget to set
+     */
+    public void setSyncTarget(String syncTarget) {
+        this.syncTarget = syncTarget;
+    }
+
+    /**
+     * @return absolute server-side path for the HTML export; when non-empty,
+     *         every backup also creates a browser-viewable HTML export of all
+     *         cases (incremental), empty means disabled
+     */
+    public String getExportTarget() {
+        return exportTarget;
+    }
+
+    /**
+     * @param exportTarget the exportTarget to set
+     */
+    public void setExportTarget(String exportTarget) {
+        this.exportTarget = exportTarget;
+    }
+
+    /**
+     * @return true if a notification email is sent on successful backup
+     */
+    public boolean isNotifyOnSuccess() {
+        return notifyOnSuccess;
+    }
+
+    /**
+     * @param notifyOnSuccess the notifyOnSuccess to set
+     */
+    public void setNotifyOnSuccess(boolean notifyOnSuccess) {
+        this.notifyOnSuccess = notifyOnSuccess;
+    }
+
+    /**
+     * @return true if a notification email is sent on backup failure
+     */
+    public boolean isNotifyOnFailure() {
+        return notifyOnFailure;
+    }
+
+    /**
+     * @param notifyOnFailure the notifyOnFailure to set
+     */
+    public void setNotifyOnFailure(boolean notifyOnFailure) {
+        this.notifyOnFailure = notifyOnFailure;
+    }
+
 }

--- a/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/services/SystemManagement.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/services/SystemManagement.java
@@ -931,8 +931,7 @@ public class SystemManagement implements SystemManagementRemote, SystemManagemen
     @RolesAllowed({"sysAdminRole"})
     public void clearCurrentBackup() {
         // needs to be called e.g. when encryption password has changed
-        File directoryToZip = new File(System.getProperty("jlawyer.server.basedirectory").trim());
-        File backupDir = new File(directoryToZip.getParentFile().getPath() + System.getProperty("file.separator") + "backups");
+        File backupDir = new File(this.getBackupDirectory());
         backupDir.mkdirs();
 
         for (File child : backupDir.listFiles()) {
@@ -948,6 +947,18 @@ public class SystemManagement implements SystemManagementRemote, SystemManagemen
             }
 
         }
+    }
+
+    @Override
+    @RolesAllowed({"loginRole"})
+    public String getBackupDirectory() {
+        ServerSettingsBean dirSetting = this.settingsFacade.find(ServerSettingsKeys.SERVERCONF_BACKUP_DIRECTORY);
+        if (dirSetting != null && dirSetting.getSettingValue() != null && !dirSetting.getSettingValue().trim().isEmpty()) {
+            return dirSetting.getSettingValue().trim();
+        }
+        // default: sibling "backups" directory of the server base directory
+        File baseDir = new File(System.getProperty("jlawyer.server.basedirectory").trim());
+        return baseDir.getParentFile().getPath() + File.separator + "backups";
     }
 
     @Override

--- a/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/services/SystemManagementLocal.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/services/SystemManagementLocal.java
@@ -673,6 +673,7 @@ import com.jdimension.jlawyer.persistence.DocumentTagRule;
 import com.jdimension.jlawyer.persistence.Invoice;
 import com.jdimension.jlawyer.persistence.MappingTable;
 import com.jdimension.jlawyer.persistence.PartyTypeBean;
+import com.jdimension.jlawyer.persistence.ServerSettingsBean;
 import com.jdimension.jlawyer.server.services.MonitoringSnapshot;
 import java.util.HashMap;
 import java.util.List;
@@ -746,5 +747,21 @@ public interface SystemManagementLocal {
     DocumentNameTemplate getDefaultDocumentNameTemplate() throws Exception;
 
     List<DocumentTagRule> getAllDocumentTagRules();
+    
+    ServerSettingsBean getSetting(String key);
+    
+    boolean setSetting(String key, String value);
+    
+    void clearCurrentBackup();
+    
+    /**
+     * Returns the configured backup directory path. If a custom directory has
+     * been configured via server settings, that path is returned. Otherwise,
+     * the default path (sibling "backups" directory of the server base directory)
+     * is returned.
+     *
+     * @return the absolute path to the backup directory
+     */
+    String getBackupDirectory();
     
 }

--- a/j-lawyer-server/j-lawyer-server-war/src/java/com/jdimension/jlawyer/timer/BackupSyncTask.java
+++ b/j-lawyer-server/j-lawyer-server-war/src/java/com/jdimension/jlawyer/timer/BackupSyncTask.java
@@ -736,8 +736,17 @@ public class BackupSyncTask extends java.util.TimerTask {
                 }
             }
 
+            // check for custom backup directory setting, fall back to default
             File baseDirectory = new File(System.getProperty("jlawyer.server.basedirectory").trim());
-            File backupDir = new File(baseDirectory.getParentFile().getPath() + System.getProperty("file.separator") + "backups");
+            String backupDirPath = null;
+            ServerSettingsBean backupDirSetting = settings.find("jlawyer.server.backup.directory");
+            if (backupDirSetting != null && backupDirSetting.getSettingValue() != null && !backupDirSetting.getSettingValue().trim().isEmpty()) {
+                backupDirPath = backupDirSetting.getSettingValue().trim();
+            }
+            if (backupDirPath == null) {
+                backupDirPath = baseDirectory.getParentFile().getPath() + System.getProperty("file.separator") + "backups";
+            }
+            File backupDir = new File(backupDirPath);
             backupDir.mkdirs();
 
             if (syncLocation.length() > 0) {

--- a/j-lawyer-server/j-lawyer-server-war/src/java/com/jdimension/jlawyer/timer/IterativeBackupTask.java
+++ b/j-lawyer-server/j-lawyer-server-war/src/java/com/jdimension/jlawyer/timer/IterativeBackupTask.java
@@ -920,8 +920,23 @@ public class IterativeBackupTask extends java.util.TimerTask implements Cancella
         
         log.info("getting directories...");
         File directoryToZip = new File(System.getProperty("jlawyer.server.basedirectory").trim());
-        String backupDir = directoryToZip.getParentFile().getPath() + System.getProperty("file.separator") + "backups";
         String dataDir = directoryToZip.getParentFile().getPath() + System.getProperty("file.separator") + "j-lawyer-data";
+        
+        // check for custom backup directory setting, fall back to default
+        String backupDir = null;
+        try {
+            InitialContext icDir = new InitialContext();
+            ServerSettingsBeanFacadeLocal dirSettings = (ServerSettingsBeanFacadeLocal) icDir.lookup("java:global/j-lawyer-server/j-lawyer-server-ejb/ServerSettingsBeanFacade!com.jdimension.jlawyer.persistence.ServerSettingsBeanFacadeLocal");
+            ServerSettingsBean backupDirSetting = dirSettings.find("jlawyer.server.backup.directory");
+            if (backupDirSetting != null && backupDirSetting.getSettingValue() != null && !backupDirSetting.getSettingValue().trim().isEmpty()) {
+                backupDir = backupDirSetting.getSettingValue().trim();
+            }
+        } catch (Exception ex) {
+            log.warn("Could not read backup directory setting, using default", ex);
+        }
+        if (backupDir == null) {
+            backupDir = directoryToZip.getParentFile().getPath() + System.getProperty("file.separator") + "backups";
+        }
 
         
         log.info("initializing backup executor");


### PR DESCRIPTION
#3295

Summary
- Adds REST endpoints to read, update, and delete backup configuration via the API, complementing the existing POST /v7/administration/backup (ad-hoc trigger)
- Makes the backup directory configurable as a DB setting instead of being hardcoded to a path derived from jlawyer.server.basedirectory
- Exposes all backup settings (scheduling, database credentials, encryption, HTML export target, sync target, notifications) through a single configuration DTO
New Endpoints
Method	Path	Role	Description
GET	/v7/administration/backup/configuration	loginRole	Returns full backup configuration. Passwords are never included (write-only).
PUT	/v7/administration/backup/configuration	sysAdminRole	Updates backup configuration. Null string fields = "don't change". Validates directory existence, port range, hour range. Changing the encryption password auto-deletes existing backup data.
DELETE	/v7/administration/backup/data	sysAdminRole	Deletes all backup data (async). Same operation as triggered by encryption password change.
Configuration Fields
- Scheduling: backupMode ("on"/"off"), hour (0-23), weekday flags (monday..sunday)
- Database: dbHost, dbPort (1-65535), dbName, dbUser, dbPassword (write-only)
- Encryption: encryptionEnabled (read-only flag), encryptionPassword (write-only; change triggers backup deletion)
- Directories: backupDirectory (server path for backup data), exportTarget (server path for incremental HTML export - when set, every backup also creates a browser-viewable HTML export of all cases), syncTarget (remote FTP/SFTP/SMB URL)
- Notifications: notifyOnSuccess, notifyOnFailure
Implementation Details
- Backup directory stored as DB setting jlawyer.server.backup.directory with fallback to the previous hardcoded path (<parent-of-basedirectory>/backups/)
- SystemManagementLocal interface extended with getSetting(), setSetting(), clearCurrentBackup(), getBackupDirectory() (signatures only - implementation already existed on SystemManagement.java via the Remote interface)
- IterativeBackupTask and BackupSyncTask updated to read backup directory from DB setting with fallback
- clearCurrentBackup() refactored to use getBackupDirectory() instead of hardcoded path derivation
- JAX-RS Analyzer classpath in j-lawyer-io/build.xml extended with j-lawyer-server-ejb.jar (needed because endpoint now imports SystemManagementLocal)