### PR TITLE
Preserve INGO_TEXT paragraphs in ODT templates

### DIFF
--- a/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/documents/LibreOfficeAccess.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/java/com/jdimension/jlawyer/documents/LibreOfficeAccess.java
@@ -1503,13 +1503,32 @@ public class LibreOfficeAccess {
                     String[] trailingCharsRegex = new String[]{"\\.", ",", ";", ":", "!", "\\?", "'", "\"", " "};
                     String[] trailingChars = new String[]{".", ",", ";", ":", "!", "?", "'", "\"", " "};
 
+                    String value = (String) values.get(key);
+                    if (PlaceHolders.INGO_TEXT.equals(key) && isMultiParagraphText(value)) {
+                        String regExKey = "\\{\\{" + key.substring(2, key.length() - 2) + "\\}\\}";
+                        TextNavigation search = new TextNavigation(regExKey, outputOdt);
+                        ArrayList<TextSelection> selections = new ArrayList<>();
+                        while (search.hasNext()) {
+                            selections.add((TextSelection) search.nextSelection());
+                        }
+                        for (TextSelection item : selections) {
+                            try {
+                                if (!replaceIngoTextWithParagraphs(item, value)) {
+                                    item.replaceWith(value);
+                                }
+                            } catch (Throwable t) {
+                                log.error("Error replacing " + regExKey + " with " + value + " in " + fileInFileSystem, t);
+                            }
+                        }
+                        continue;
+                    }
+
                     for (int i = 0; i < trailingCharsRegex.length; i++) {
                         String trailCharRegex = trailingCharsRegex[i];
                         String trailChar = trailingChars[i];
                         String regExKey = "\\{\\{" + key.substring(2, key.length() - 2) + "\\}\\}" + trailCharRegex;
 
-                        String value = (String) values.get(key);
-                        value = value + trailChar;
+                        String trailValue = value + trailChar;
 
                         TextNavigation search = new TextNavigation(regExKey, outputOdt);
 
@@ -1517,18 +1536,19 @@ public class LibreOfficeAccess {
 
                             try {
                                 TextSelection item = (TextSelection) search.nextSelection();
-                                item.replaceWith(value);
+                                item.replaceWith(trailValue);
 
                             } catch (Throwable t) {
-                                log.error("Error replacing " + regExKey + " with " + value + " in " + fileInFileSystem, t);
+                                log.error("Error replacing " + regExKey + " with " + trailValue + " in " + fileInFileSystem, t);
                             }
                         }
                     }
 
                     String regExKey = "\\{\\{" + key.substring(2, key.length() - 2) + "\\}\\}";
-                    String value = (String) values.get(key);
                     if (value == null) {
                         value = "";
+                    } else if (PlaceHolders.INGO_TEXT.equals(key)) {
+                        // keep body text untouched; it may contain paragraph boundaries
                     } else if ("".equals(value)) {
                         // do not append space
                     } else {
@@ -1539,7 +1559,6 @@ public class LibreOfficeAccess {
                     TextNavigation search = new TextNavigation(regExKey, outputOdt);
 
                     while (search.hasNext()) {
-
                         try {
                             TextSelection item = (TextSelection) search.nextSelection();
                             item.replaceWith(value);
@@ -2111,6 +2130,43 @@ public class LibreOfficeAccess {
             PdfFormsAccess.setPlaceHolders(caseId, fileInFileSystem, fileName, values, formsPrefixes);
         }
 
+    }
+
+    private static boolean replaceIngoTextWithParagraphs(TextSelection item, String value) {
+        Node paragraphNode = item.getContainerElement();
+        if (!(paragraphNode instanceof TextPElement)) {
+            return false;
+        }
+
+        Node parentNode = paragraphNode.getParentNode();
+        if (parentNode == null) {
+            return false;
+        }
+
+        String paragraphText = paragraphNode.getTextContent();
+        int placeholderIndex = paragraphText.indexOf(PlaceHolders.INGO_TEXT);
+        if (placeholderIndex < 0) {
+            return false;
+        }
+        String before = paragraphText.substring(0, placeholderIndex);
+        String after = paragraphText.substring(placeholderIndex + PlaceHolders.INGO_TEXT.length());
+        if (before.trim().length() > 0 || !after.matches("[\\.,;:!\\?'\" ]*")) {
+            return false;
+        }
+
+        String normalized = value.replace("\r\n", "\n").replace('\r', '\n').trim();
+        String[] paragraphs = normalized.split("\\n\\s*\\n");
+        for (int p = 0; p < paragraphs.length; p++) {
+            Node newParagraph = paragraphNode.cloneNode(false);
+            newParagraph.setTextContent(paragraphs[p] + (p == paragraphs.length - 1 ? after : ""));
+            parentNode.insertBefore(newParagraph, paragraphNode);
+        }
+        parentNode.removeChild(paragraphNode);
+        return true;
+    }
+
+    private static boolean isMultiParagraphText(String value) {
+        return value != null && value.replace("\r\n", "\n").replace('\r', '\n').matches("(?s).*\\n\\s*\\n.*");
     }
 
     private static boolean isContainedAsSeparateParagraph(Node rNode, String searchText) {

--- a/j-lawyer-server/j-lawyer-server-ejb/test/org/jlawyer/test/server/ejb/LibreOfficeODFTest.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/test/org/jlawyer/test/server/ejb/LibreOfficeODFTest.java
@@ -682,6 +682,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.zip.ZipFile;
 import junit.framework.Assert;
 import org.apache.tika.Tika;
 import org.junit.After;
@@ -817,6 +818,34 @@ public class LibreOfficeODFTest {
         Assert.assertEquals(109, content.indexOf("hans otto 2"));
         Assert.assertTrue(!content.contains("MANDANT_ANREDE"));
 
+    }
+
+    @Test
+    public void setIngoTextPreservesParagraphsInOdt() {
+        File f = null;
+        try {
+            f = File.createTempFile("j-lawyer-ingo-text-", ".odt");
+            TextDocument document = TextDocument.newTextDocument();
+            document.addParagraph("{{INGO_TEXT}}. ");
+            document.save(f);
+            document.close();
+
+            HashMap<String,Object> ph = new HashMap<>();
+            ph.put("{{INGO_TEXT}}", "First paragraph\n\nSecond paragraph\n\nThird paragraph");
+
+            LibreOfficeAccess.setPlaceHolders("", f.getAbsolutePath(), f.getName(), ph, null);
+
+            String contentXml = readZipEntry(f, "content.xml");
+            Assert.assertFalse(contentXml.contains("<text:line-break"));
+            Assert.assertTrue(java.util.regex.Pattern.compile("(?s).*First paragraph</text:p><text:p[^>]*>Second paragraph</text:p><text:p[^>]*>Third paragraph\\..*").matcher(contentXml).matches());
+        } catch (Throwable t) {
+            t.printStackTrace();
+            Assert.fail(t.getMessage());
+        } finally {
+            if (f != null) {
+                f.delete();
+            }
+        }
     }
 
     @Test
@@ -1391,6 +1420,17 @@ public class LibreOfficeODFTest {
             int length;
             while ((length = is.read(buffer)) > 0) {
                 os.write(buffer, 0, length);
+            }
+        }
+    }
+
+    private static String readZipEntry(File file, String entryName) throws IOException {
+        try ( ZipFile zip = new ZipFile(file)) {
+            if (zip.getEntry(entryName) == null) {
+                throw new IOException("ZIP entry not found: " + entryName);
+            }
+            try ( InputStream is = zip.getInputStream(zip.getEntry(entryName))) {
+                return new String(is.readAllBytes(), "UTF-8");
             }
         }
     }


### PR DESCRIPTION
## Summary
- preserve multiline `{{INGO_TEXT}}` values as separate ODT paragraphs instead of `<text:line-break/>` entries
- handle placeholders followed by punctuation or spaces before the generic trailing-character replacement path
- add regression coverage for `{{INGO_TEXT}}. `

Fixes #3323.

## Testing
- Previously passed in a disposable Docker container: `ant -f j-lawyer-server/j-lawyer-server-ejb/build.xml -Dj2ee.server.home=/opt/jboss/wildfly -Djavac.includes=org/jlawyer/test/server/ejb/LibreOfficeODFTest.java -Dtest.class=org.jlawyer.test.server.ejb.LibreOfficeODFTest -Dtest.method=setIngoTextPreservesParagraphsInOdt test-single-method`
- After rebasing onto current upstream `master`, the same command fails before this test runs while compiling `j-lawyer-server-api`, due missing unrelated dependency classes such as `BaseInterest`, `PaymentSplitProposal`, and Dropscan classes in this container setup.