### PR TITLE
Remember file chooser directories

### DIFF
--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/bea/BeaMessageContentUI.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/bea/BeaMessageContentUI.java
@@ -1401,26 +1401,16 @@ public class BeaMessageContentUI extends javax.swing.JPanel implements Hyperlink
         }
 
         try {
-            String userHome = System.getProperty("user.home");
-            if (!userHome.endsWith(File.separator)) {
-                userHome = userHome + File.separator;
-            }
-            String selectedFolder = null;
             for (Object selected : attList.getSelectedValuesList()) {
 
                 BeaAttachment att = (BeaAttachment) selected;
                 byte[] data = ensureAttachmentContent(att);
 
-                String useFolder = userHome;
-                if (selectedFolder != null) {
-                    useFolder = selectedFolder;
-                }
-
                 boolean validName = false;
                 File f = null;
                 boolean skipToNext = false;
                 while (!validName) {
-                    JFileChooser chooser = new JFileChooser(useFolder);
+                    JFileChooser chooser = FileChooserUtils.createFileChooser();
                     chooser.setSelectedFile(new File(selected.toString()));
                     int result = chooser.showSaveDialog(this);
                     if (result == JFileChooser.CANCEL_OPTION) {
@@ -1432,6 +1422,7 @@ public class BeaMessageContentUI extends javax.swing.JPanel implements Hyperlink
                     if (f == null) {
                         return;
                     }
+                    FileChooserUtils.rememberDirectory(chooser);
 
                     if (f.exists()) {
                         int response = JOptionPane.showConfirmDialog(this, "Die Datei existiert bereits. Überschreiben?", "Datei überschreiben", JOptionPane.YES_NO_OPTION);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/CustomLauncherOptionsDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/CustomLauncherOptionsDialog.java
@@ -673,6 +673,7 @@ import com.jdimension.jlawyer.client.launcher.Launcher;
 import com.jdimension.jlawyer.client.launcher.LauncherFactory;
 import com.jdimension.jlawyer.client.launcher.ReadOnlyDocumentStore;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import java.awt.event.MouseEvent;
 import java.io.File;
@@ -1052,11 +1053,12 @@ public class CustomLauncherOptionsDialog extends javax.swing.JDialog {
             return;
         }
 
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         ExtensionFilter filter = new ExtensionFilter(this.txtExtension.getText());
         chooser.setFileFilter(filter);
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
 
             try {
                 String url = chooser.getSelectedFile().getCanonicalPath();
@@ -1120,9 +1122,10 @@ public class CustomLauncherOptionsDialog extends javax.swing.JDialog {
             return;
         }
 
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
 
             try {
                 this.txtExecutable.setText(chooser.getSelectedFile().getCanonicalPath());

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/ImportContactsDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/ImportContactsDialog.java
@@ -664,6 +664,7 @@
 package com.jdimension.jlawyer.client.configuration;
 
 import com.jdimension.jlawyer.client.settings.ClientSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.StringUtils;
 import com.jdimension.jlawyer.persistence.AddressBean;
 import com.jdimension.jlawyer.services.AddressServiceRemote;
@@ -865,11 +866,12 @@ public class ImportContactsDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmdCloseActionPerformed
 
     private void cmdChooseVCardActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdChooseVCardActionPerformed
-        JFileChooser fc = new JFileChooser();
+        JFileChooser fc = FileChooserUtils.createFileChooser();
         fc.setFileFilter(new VCardFileFilter());
         fc.setMultiSelectionEnabled(false);
 
         if (fc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(fc);
             try {
                 this.taLog.setText("");
                 ClientSettings settings = ClientSettings.getInstance();

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/ImportFromSheetsDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/ImportFromSheetsDialog.java
@@ -664,6 +664,7 @@
 package com.jdimension.jlawyer.client.configuration;
 
 import com.jdimension.jlawyer.client.settings.ClientSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.VersionUtils;
 import com.jdimension.jlawyer.pojo.imports.ImportLogEntry;
@@ -839,12 +840,13 @@ public class ImportFromSheetsDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmdCloseActionPerformed
 
     private void downloadOrExport(boolean export) {
-        JFileChooser chooser = new JFileChooser(System.getProperty("user.home"));
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         chooser.setAcceptAllFileFilterUsed(false);
         chooser.setDialogTitle("Verzeichnis wählen");
         chooser.setApproveButtonText("Auswählen");
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
             
             String destFileName = null;
             if(export)
@@ -880,11 +882,12 @@ public class ImportFromSheetsDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmdDownloadTemplateActionPerformed
 
     private void cmdUploadSheetActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdUploadSheetActionPerformed
-        JFileChooser fc = new JFileChooser();
+        JFileChooser fc = FileChooserUtils.createFileChooser();
         fc.setFileFilter(new ODSFileFilter());
         fc.setMultiSelectionEnabled(false);
 
         if (fc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(fc);
             try {
                 this.taLog.setText("");
                 ClientSettings settings = ClientSettings.getInstance();

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/UserAdministrationDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/UserAdministrationDialog.java
@@ -679,6 +679,7 @@ import com.jdimension.jlawyer.client.editors.EditorsRegistry;
 import com.jdimension.jlawyer.client.settings.ServerSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.FrameUtils;
 import com.jdimension.jlawyer.client.utils.StringUtils;
@@ -2749,9 +2750,10 @@ public class UserAdministrationDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmbCountryItemStateChanged
 
     private void cmdSelectCertificateActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdSelectCertificateActionPerformed
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
 
             try {
                 String url = chooser.getSelectedFile().getCanonicalPath();

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/VoipSoftphoneConfigurationDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/configuration/VoipSoftphoneConfigurationDialog.java
@@ -664,6 +664,7 @@
 package com.jdimension.jlawyer.client.configuration;
 
 import com.jdimension.jlawyer.client.settings.ClientSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.voip.VoipUtils;
 import java.io.IOException;
 import javax.swing.JFileChooser;
@@ -905,10 +906,11 @@ public class VoipSoftphoneConfigurationDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmdCancelActionPerformed
 
     private void cmdFindExecutableActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdFindExecutableActionPerformed
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         chooser.setFileHidingEnabled(false);
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
 
             try {
                 this.txtExecutable.setText(chooser.getSelectedFile().getCanonicalPath());

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/documents/SaveDocumentsLocallyDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/documents/SaveDocumentsLocallyDialog.java
@@ -668,6 +668,7 @@ import com.jdimension.jlawyer.client.launcher.LauncherFactory;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
 import com.jdimension.jlawyer.client.utils.FileConverter;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.StringUtils;
 import com.jdimension.jlawyer.persistence.ArchiveFileDocumentsBean;
@@ -701,20 +702,7 @@ public class SaveDocumentsLocallyDialog extends javax.swing.JDialog {
         this.convertToPdf = convertToPdf;
         initComponents();
 
-        ClientSettings settings = ClientSettings.getInstance();
-        String lastDir = settings.getConfiguration("client.archivefiles.encryptedpdf.lastdir", System.getProperty("user.home"));
-        if (!lastDir.endsWith(File.separator)) {
-            lastDir = lastDir + File.separator;
-        }
-
-        if (!(new File(lastDir).exists())) {
-            lastDir = System.getProperty("user.home");
-            if (!lastDir.endsWith(File.separator)) {
-                lastDir = lastDir + File.separator;
-            }
-        }
-
-        this.txtLastDir.setText(lastDir);
+        this.txtLastDir.setText(FileChooserUtils.getStartDirectoryPath("client.archivefiles.encryptedpdf.lastdir"));
 
     }
 
@@ -815,6 +803,7 @@ public class SaveDocumentsLocallyDialog extends javax.swing.JDialog {
         chooser.setDialogTitle("Verzeichnis wählen");
         chooser.setApproveButtonText("Auswählen");
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory("client.archivefiles.encryptedpdf.lastdir", chooser);
             this.txtLastDir.setText(chooser.getSelectedFile().getAbsolutePath());
         }
     }//GEN-LAST:event_cmdBrowseActionPerformed

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -5979,22 +5979,12 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
     }//GEN-LAST:event_cmdUploadDocumentActionPerformed
 
     public boolean uploadDocument(Invoice invoice) {
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_CASE_LASTUPLOADDIR);
         chooser.setMultiSelectionEnabled(invoice == null);
-
-        ClientSettings settings = ClientSettings.getInstance();
-        String lastUploadDir = settings.getConfiguration(ClientSettings.CONF_CASE_LASTUPLOADDIR, null);
-        if (lastUploadDir != null) {
-            File lud = new File(lastUploadDir);
-            if (lud.exists()) {
-                if (lud.isDirectory()) {
-                    chooser.setCurrentDirectory(lud);
-                }
-            }
-        }
 
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(ClientSettings.CONF_CASE_LASTUPLOADDIR, chooser);
             try {
                 File[] fileArray = null;
                 if (chooser.isMultiSelectionEnabled()) {
@@ -6004,17 +5994,8 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
                     fileArray[0] = chooser.getSelectedFile();
                 }
                 ArrayList<File> files = new ArrayList<>();
-                boolean lastUploadSaved = false;
                 for (File f : fileArray) {
                     files.add(f);
-
-                    if (f.isFile() && !lastUploadSaved) {
-                        String parent = f.getParent();
-                        if (parent != null) {
-                            settings.setConfiguration(ClientSettings.CONF_CASE_LASTUPLOADDIR, parent);
-                            lastUploadSaved = true;
-                        }
-                    }
                 }
 
                 if (invoice == null) {
@@ -6462,32 +6443,14 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
 
     private void cmdExportHtmlActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdExportHtmlActionPerformed
 
-        ClientSettings s = ClientSettings.getInstance();
-        String lastDir = s.getConfiguration(ClientSettings.CONF_CASES_EXPORT_LASTDIR, System.getProperty("user.home"));
-
-        if (!lastDir.endsWith(File.separator)) {
-            lastDir = lastDir + File.separator;
-        }
-
-        if (!(new File(lastDir).exists())) {
-            lastDir = System.getProperty("user.home");
-            if (!lastDir.endsWith(File.separator)) {
-                lastDir = lastDir + File.separator;
-            }
-        }
-
-        JFileChooser chooser = new JFileChooser(lastDir);
+        JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_CASES_EXPORT_LASTDIR);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         chooser.setAcceptAllFileFilterUsed(false);
         chooser.setDialogTitle("Verzeichnis wählen");
         chooser.setApproveButtonText("Auswählen");
         if (chooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(ClientSettings.CONF_CASES_EXPORT_LASTDIR, chooser);
             File dir = chooser.getSelectedFile();
-            try {
-                s.setConfiguration(ClientSettings.CONF_CASES_EXPORT_LASTDIR, dir.getCanonicalPath());
-            } catch (Throwable t) {
-                log.error("can not get canonical path during html export", t);
-            }
 
             ProgressIndicator dlg = new ProgressIndicator(EditorsRegistry.getInstance().getMainWindow(), true);
             dlg.setShowCancelButton(true);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/CaseExportDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/CaseExportDialog.java
@@ -11,6 +11,7 @@ import com.jdimension.jlawyer.client.processing.ProgressableAction;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
 import com.jdimension.jlawyer.client.utils.DesktopUtils;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.ThreadUtils;
 import com.jdimension.jlawyer.persistence.ArchiveFileBean;
 import com.jdimension.jlawyer.pojo.DataBucket;
@@ -223,12 +224,13 @@ public class CaseExportDialog extends javax.swing.JDialog {
             return;
         }
 
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_CASES_EXPORT_LASTDIR);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         chooser.setDialogTitle("Zielordner für den Export auswählen");
         int result = chooser.showSaveDialog(this);
 
         if (result == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(ClientSettings.CONF_CASES_EXPORT_LASTDIR, chooser);
             File destinationDir = chooser.getSelectedFile();
             dispose();
 

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/DownloadDocumentsAction.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/DownloadDocumentsAction.java
@@ -668,6 +668,7 @@ import com.jdimension.jlawyer.client.editors.documents.CachingDocumentLoader;
 import com.jdimension.jlawyer.client.processing.ProgressIndicator;
 import com.jdimension.jlawyer.client.processing.ProgressableAction;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.ThreadUtils;
 import com.jdimension.jlawyer.persistence.*;
 import com.jdimension.jlawyer.services.ArchiveFileServiceRemote;
@@ -783,12 +784,13 @@ public class DownloadDocumentsAction extends ProgressableAction {
                         SwingUtilities.invokeLater(new Runnable() {
                             @Override
                             public void run() {
-                                JFileChooser chooser = new JFileChooser();
+                                JFileChooser chooser = FileChooserUtils.createFileChooser();
                                 chooser.setDialogTitle("XJustiz-Viewer suchen...");
                                 ExeFilter filter = new ExeFilter();
                                 chooser.setFileFilter(filter);
                                 int returnVal = chooser.showOpenDialog(EditorsRegistry.getInstance().getMainWindow());
                                 if (returnVal == JFileChooser.APPROVE_OPTION) {
+                                    FileChooserUtils.rememberDirectory(chooser);
 
                                     File exe = chooser.getSelectedFile();
                                     File path = exe.getParentFile();

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ExportAsPdfMergeStep.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/ExportAsPdfMergeStep.java
@@ -669,6 +669,7 @@ import com.jdimension.jlawyer.client.events.DocumentAddedEvent;
 import com.jdimension.jlawyer.client.events.EventBroker;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.ThreadUtils;
 import com.jdimension.jlawyer.client.wizard.*;
@@ -750,30 +751,14 @@ public class ExportAsPdfMergeStep extends javax.swing.JPanel implements WizardSt
             uset.setSettingAsBoolean(UserSettings.CONF_CASES_EXPORT_TOCASE, this.chkSaveToCase.isSelected());
             if (this.chkSaveLocally.isSelected()) {
                 
-                String lastDir = s.getConfiguration(ClientSettings.CONF_CASES_EXPORT_LASTDIR, System.getProperty("user.home"));
-                if (!lastDir.endsWith(File.separator)) {
-                    lastDir = lastDir + File.separator;
-                }
-
-                if (!(new File(lastDir).exists())) {
-                    lastDir = System.getProperty("user.home");
-                    if (!lastDir.endsWith(File.separator)) {
-                        lastDir = lastDir + File.separator;
-                    }
-                }
-
-                JFileChooser chooser = new JFileChooser(lastDir);
+                JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_CASES_EXPORT_LASTDIR);
                 chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
                 chooser.setAcceptAllFileFilterUsed(false);
                 chooser.setDialogTitle("Verzeichnis wählen");
                 chooser.setApproveButtonText("Speichern");
                 if (chooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
+                    FileChooserUtils.rememberDirectory(ClientSettings.CONF_CASES_EXPORT_LASTDIR, chooser);
                     File dir = chooser.getSelectedFile();
-                    try {
-                        s.setConfiguration(ClientSettings.CONF_CASES_EXPORT_LASTDIR, dir.getCanonicalPath());
-                    } catch (Throwable t) {
-                        log.error("can not get canonical path during html export", t);
-                    }
 
                     String fullResultFile = dir.getAbsolutePath() + File.separator + new File(resultFile).getName();
                     if (new File(fullResultFile).exists()) {

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/finance/ImportBankStatementFrame.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/finance/ImportBankStatementFrame.java
@@ -668,6 +668,7 @@ import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
 import com.jdimension.jlawyer.client.utils.DateUtils;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.StringUtils;
 import com.jdimension.jlawyer.client.utils.ThreadUtils;
 import com.jdimension.jlawyer.persistence.AddressBean;
@@ -1182,17 +1183,10 @@ public class ImportBankStatementFrame extends javax.swing.JFrame {
     }// </editor-fold>//GEN-END:initComponents
 
     private void cmdCsvUploadActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdCsvUploadActionPerformed
-        JFileChooser chooser = new JFileChooser();
-        ClientSettings cs = ClientSettings.getInstance();
-        String lastDir = cs.getConfiguration(ClientSettings.CONF_BANKSTATEMENT_CSV_LASTDIR, null);
-        if (lastDir != null) {
-            File dir = new File(lastDir);
-            if (dir.exists() && dir.isDirectory()) {
-                chooser.setCurrentDirectory(dir);
-            }
-        }
+        JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_BANKSTATEMENT_CSV_LASTDIR);
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(ClientSettings.CONF_BANKSTATEMENT_CSV_LASTDIR, chooser);
 
             BankStatementsCSVConfig csvConfig = null;
             for (BankStatementsCSVConfig c : this.csvConfigs) {
@@ -1217,7 +1211,6 @@ public class ImportBankStatementFrame extends javax.swing.JFrame {
 
                 String url = chooser.getSelectedFile().getCanonicalPath();
                 File f = new File(url);
-                cs.setConfiguration(ClientSettings.CONF_BANKSTATEMENT_CSV_LASTDIR, f.getParent());
 
                 // Create a DecimalFormat with German locale (comma as decimal separator)
                 DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag(csvConfig.getLocale()));

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/finance/ManagePaymentsFrame.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/editors/finance/ManagePaymentsFrame.java
@@ -666,6 +666,7 @@ package com.jdimension.jlawyer.client.editors.finance;
 import com.jdimension.jlawyer.client.editors.files.PaymentMgmtEntryPanel;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.settings.UserSettings;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.StringUtils;
 import com.jdimension.jlawyer.persistence.AppUserBean;
 import com.jdimension.jlawyer.persistence.Payment;
@@ -930,28 +931,14 @@ public class ManagePaymentsFrame extends javax.swing.JFrame {
                 sepaString = sepaString.replace("CstmrCdtTrfInitn xmlns=\"\"", "CstmrCdtTrfInitn");
                 sepaString = sepaString.replace("<BtchBookg>true</BtchBookg>", "<BtchBookg>false</BtchBookg>");
 
-                String lastDir = settings.getConfiguration(ClientSettings.CONF_FINANCE_SEPAXML_LASTDIR, System.getProperty("user.home"));
-                if (!lastDir.endsWith(File.separator)) {
-                    lastDir = lastDir + File.separator;
-                }
-                if (!(new File(lastDir).exists())) {
-                    lastDir = System.getProperty("user.home");
-                    if (!lastDir.endsWith(File.separator)) {
-                        lastDir = lastDir + File.separator;
-                    }
-                }
-                JFileChooser chooser = new JFileChooser(lastDir);
+                JFileChooser chooser = FileChooserUtils.createFileChooser(ClientSettings.CONF_FINANCE_SEPAXML_LASTDIR);
                 chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
                 chooser.setAcceptAllFileFilterUsed(false);
                 chooser.setDialogTitle("Verzeichnis wählen");
                 chooser.setApproveButtonText("Auswählen");
                 if (chooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
+                    FileChooserUtils.rememberDirectory(ClientSettings.CONF_FINANCE_SEPAXML_LASTDIR, chooser);
                     File dir = chooser.getSelectedFile();
-                    try {
-                        settings.setConfiguration(ClientSettings.CONF_FINANCE_SEPAXML_LASTDIR, dir.getCanonicalPath());
-                    } catch (Throwable t) {
-                        log.error("can not get canonical path during sepa export", t);
-                    }
 
                     String fileName = dir.getPath() + File.separator + new SimpleDateFormat("yyyyMMdd_HHmm_").format(new Date()) + "_SEPA-Export_" + iban + ".xml";
                     FileWriter fw = new FileWriter(fileName);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/encryption/PDFEncryptionDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/encryption/PDFEncryptionDialog.java
@@ -665,8 +665,8 @@ package com.jdimension.jlawyer.client.encryption;
 
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.persistence.AddressBean;
-import java.io.File;
 import java.util.ArrayList;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -695,20 +695,7 @@ public class PDFEncryptionDialog extends javax.swing.JDialog {
         initComponents();
         this.cmbRecipient.removeAllItems();
 
-        ClientSettings settings = ClientSettings.getInstance();
-        String lastDir = settings.getConfiguration("client.archivefiles.encryptedpdf.lastdir", System.getProperty("user.home"));
-        if (!lastDir.endsWith(File.separator)) {
-            lastDir = lastDir + File.separator;
-        }
-
-        if (!(new File(lastDir).exists())) {
-            lastDir = System.getProperty("user.home");
-            if (!lastDir.endsWith(File.separator)) {
-                lastDir = lastDir + File.separator;
-            }
-        }
-
-        this.txtLastDir.setText(lastDir);
+        this.txtLastDir.setText(FileChooserUtils.getStartDirectoryPath("client.archivefiles.encryptedpdf.lastdir"));
 
     }
 
@@ -853,6 +840,7 @@ public class PDFEncryptionDialog extends javax.swing.JDialog {
         chooser.setDialogTitle("Verzeichnis wählen");
         chooser.setApproveButtonText("Auswählen");
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory("client.archivefiles.encryptedpdf.lastdir", chooser);
             this.txtLastDir.setText(chooser.getSelectedFile().getAbsolutePath());
         }
     }//GEN-LAST:event_cmdBrowseActionPerformed

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/mail/MailContentUI.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/mail/MailContentUI.java
@@ -2159,11 +2159,6 @@ public class MailContentUI extends javax.swing.JPanel implements HyperlinkListen
         }
 
         try {
-            String userHome = System.getProperty("user.home");
-            if (!userHome.endsWith(File.separator)) {
-                userHome = userHome + File.separator;
-            }
-            String selectedFolder = null;
             for (Object selected : this.lstAttachments.getSelectedValuesList()) {
 
                 byte[] data = null;
@@ -2182,16 +2177,11 @@ public class MailContentUI extends javax.swing.JPanel implements HyperlinkListen
                     }
                 }
 
-                String useFolder = userHome;
-                if (selectedFolder != null) {
-                    useFolder = selectedFolder;
-                }
-
                 boolean validName = false;
                 File f = null;
                 boolean skipToNext = false;
                 while (!validName) {
-                    JFileChooser chooser = new JFileChooser(useFolder);
+                    JFileChooser chooser = FileChooserUtils.createFileChooser();
                     chooser.setSelectedFile(new File(selected.toString()));
                     int result = chooser.showSaveDialog(this);
                     if (result == JFileChooser.CANCEL_OPTION) {
@@ -2202,6 +2192,7 @@ public class MailContentUI extends javax.swing.JPanel implements HyperlinkListen
                     if (f == null) {
                         return;
                     }
+                    FileChooserUtils.rememberDirectory(chooser);
 
                     if (f.exists()) {
                         int response = JOptionPane.showConfirmDialog(this, "Die Datei existiert bereits. Überschreiben?", "Datei überschreiben", JOptionPane.YES_NO_OPTION);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/settings/ClientSettings.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/settings/ClientSettings.java
@@ -775,6 +775,7 @@ public class ClientSettings {
     public static final String CONF_BEA_SAVETOARCHIVEFILE="client.bea.savetoarchivefile";
     
     public static final String CONF_CASE_LASTUPLOADDIR="client.case.lastuploaddir";
+    public static final String CONF_FILECHOOSER_LASTDIR="client.filechooser.lastdir";
     
     public static final String CONF_MAIL_HTMLWHITELIST="client.mail.htmlwhitelist";
     public static final String CONF_MAIL_SAVETOARCHIVEFILE="client.mail.savetoarchivefile";

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/templates/TemplatesTreePanel.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/templates/TemplatesTreePanel.java
@@ -674,6 +674,7 @@ import com.jdimension.jlawyer.client.processing.ProgressIndicator;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
 import com.jdimension.jlawyer.client.utils.FileConverter;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.FrameUtils;
 import com.jdimension.jlawyer.client.utils.JTreeUtils;
@@ -1187,10 +1188,11 @@ public class TemplatesTreePanel extends javax.swing.JPanel implements ThemeableE
     }//GEN-LAST:event_cmdNewODSActionPerformed
 
     private void cmdAddExistingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdAddExistingActionPerformed
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         chooser.setMultiSelectionEnabled(true);
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
+            FileChooserUtils.rememberDirectory(chooser);
             try {
                 File[] fileArray = chooser.getSelectedFiles();
                 ArrayList<File> files = new ArrayList<>();

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/BugReportDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/BugReportDialog.java
@@ -1192,12 +1192,13 @@ public class BugReportDialog extends javax.swing.JDialog {
             
             byte[] zipReport=this.getReportAsZip();
             
-            JFileChooser chooser = new JFileChooser(System.getProperty("user.home"));
+            JFileChooser chooser = FileChooserUtils.createFileChooser();
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             chooser.setAcceptAllFileFilterUsed(false);
             chooser.setDialogTitle("Speicherort wählen");
             chooser.setApproveButtonText("Hier speichern");
             if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+                FileChooserUtils.rememberDirectory(chooser);
                 SimpleDateFormat df=new SimpleDateFormat("yyyy-MM-dd_HH-mm");
                 FileOutputStream fout=new FileOutputStream(new File(chooser.getSelectedFile().getAbsolutePath() + File.separator + df.format(new Date()) + "_j-lawyer-Systeminfos.zip"));
                 fout.write(zipReport);

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/FileChooserUtils.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/FileChooserUtils.java
@@ -1,0 +1,140 @@
+/*
+ *                     GNU AFFERO GENERAL PUBLIC LICENSE
+ *                        Version 3, 19 November 2007
+ */
+package com.jdimension.jlawyer.client.utils;
+
+import com.jdimension.jlawyer.client.settings.ClientSettings;
+import java.io.File;
+import javax.swing.JFileChooser;
+
+/**
+ *
+ * @author jens
+ */
+public final class FileChooserUtils {
+
+    private FileChooserUtils() {
+    }
+
+    public static JFileChooser createFileChooser() {
+        return createFileChooser(ClientSettings.CONF_FILECHOOSER_LASTDIR);
+    }
+
+    public static JFileChooser createFileChooser(String lastDirectoryKey) {
+        File startDirectory = getStartDirectory(lastDirectoryKey);
+        if (startDirectory == null) {
+            return new JFileChooser();
+        }
+        return new JFileChooser(startDirectory);
+    }
+
+    public static String getStartDirectoryPath(String lastDirectoryKey) {
+        File startDirectory = getStartDirectory(lastDirectoryKey);
+        if (startDirectory == null) {
+            File currentDirectory = new JFileChooser().getCurrentDirectory();
+            if (currentDirectory != null) {
+                return currentDirectory.getAbsolutePath();
+            }
+            return new File(".").getAbsolutePath();
+        }
+        return startDirectory.getAbsolutePath();
+    }
+
+    public static void configureStartDirectory(JFileChooser chooser) {
+        configureStartDirectory(chooser, ClientSettings.CONF_FILECHOOSER_LASTDIR);
+    }
+
+    public static void configureStartDirectory(JFileChooser chooser, String lastDirectoryKey) {
+        File startDirectory = getStartDirectory(lastDirectoryKey);
+        if (startDirectory != null) {
+            chooser.setCurrentDirectory(startDirectory);
+        }
+    }
+
+    public static void rememberDirectory(JFileChooser chooser) {
+        rememberDirectory(ClientSettings.CONF_FILECHOOSER_LASTDIR, chooser);
+    }
+
+    public static void rememberDirectory(String lastDirectoryKey, JFileChooser chooser) {
+        File directory = getSelectedDirectory(chooser);
+        if (directory == null || !directory.exists() || !directory.isDirectory()) {
+            return;
+        }
+
+        ClientSettings settings = ClientSettings.getInstance();
+        if (lastDirectoryKey != null) {
+            settings.setConfiguration(lastDirectoryKey, directory.getAbsolutePath());
+        }
+        if (isSharedLastDirectoryKey(lastDirectoryKey)) {
+            settings.setConfiguration(ClientSettings.CONF_FILECHOOSER_LASTDIR, directory.getAbsolutePath());
+        }
+    }
+
+    private static File getStartDirectory(String lastDirectoryKey) {
+        ClientSettings settings = ClientSettings.getInstance();
+        File startDirectory = getConfiguredDirectory(settings, lastDirectoryKey);
+        if (startDirectory == null && isSharedLastDirectoryKey(lastDirectoryKey)) {
+            startDirectory = getConfiguredDirectory(settings, ClientSettings.CONF_FILECHOOSER_LASTDIR);
+        }
+        if (startDirectory == null) {
+            startDirectory = getFallbackDirectory();
+        }
+        return startDirectory;
+    }
+
+    private static File getConfiguredDirectory(ClientSettings settings, String key) {
+        if (key == null) {
+            return null;
+        }
+        String path = settings.getConfiguration(key, null);
+        if (path == null || "".equals(path.trim())) {
+            return null;
+        }
+
+        File directory = new File(path);
+        return directory.exists() && directory.isDirectory() ? directory : null;
+    }
+
+    private static File getSelectedDirectory(JFileChooser chooser) {
+        if (chooser == null) {
+            return null;
+        }
+
+        File selectedFile = chooser.getSelectedFile();
+        if (chooser.getFileSelectionMode() == JFileChooser.DIRECTORIES_ONLY) {
+            if (selectedFile != null && selectedFile.exists() && selectedFile.isDirectory()) {
+                return selectedFile;
+            }
+            return chooser.getCurrentDirectory();
+        }
+        if (selectedFile == null) {
+            File[] selectedFiles = chooser.getSelectedFiles();
+            if (selectedFiles != null && selectedFiles.length > 0) {
+                selectedFile = selectedFiles[0];
+            }
+        }
+        if (selectedFile == null) {
+            selectedFile = chooser.getCurrentDirectory();
+        }
+
+        if (selectedFile == null) {
+            return null;
+        }
+        return selectedFile.isDirectory() ? selectedFile : selectedFile.getParentFile();
+    }
+
+    private static boolean isSharedLastDirectoryKey(String lastDirectoryKey) {
+        return lastDirectoryKey == null || ClientSettings.CONF_FILECHOOSER_LASTDIR.equals(lastDirectoryKey);
+    }
+
+    private static File getFallbackDirectory() {
+        File home = new File(System.getProperty("user.home", "."));
+        if (home.exists() && home.isDirectory()) {
+            return home;
+        }
+
+        File currentDirectory = new File(".").getAbsoluteFile();
+        return currentDirectory.exists() && currentDirectory.isDirectory() ? currentDirectory : null;
+    }
+}

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/SelectAttachmentDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/utils/SelectAttachmentDialog.java
@@ -733,6 +733,7 @@ public class SelectAttachmentDialog extends javax.swing.JDialog {
     }
     
     private void initialize(String caseId) {
+        FileChooserUtils.configureStartDirectory(fileChooser);
         this.txtSearch.putClientProperty("JTextField.showClearButton", true);
         this.txtSearch.putClientProperty("JTextField.placeholderText", "Suche nach Dateinamen");
         this.txtSearch.getDocument().addDocumentListener(new DocumentListener() {
@@ -904,6 +905,9 @@ public class SelectAttachmentDialog extends javax.swing.JDialog {
 
     private void fileChooserActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_fileChooserActionPerformed
         this.selectedFiles = fileChooser.getSelectedFiles();
+        if (this.selectedFiles != null && this.selectedFiles.length > 0) {
+            FileChooserUtils.rememberDirectory(fileChooser);
+        }
         this.setVisible(false);
         this.dispose();
     }//GEN-LAST:event_fileChooserActionPerformed

--- a/j-lawyer-client/src/com/jdimension/jlawyer/client/voip/SendFaxDialog.java
+++ b/j-lawyer-client/src/com/jdimension/jlawyer/client/voip/SendFaxDialog.java
@@ -667,6 +667,7 @@ import com.jdimension.jlawyer.client.editors.files.AddressBeanListCellRenderer;
 import com.jdimension.jlawyer.client.settings.ClientSettings;
 import com.jdimension.jlawyer.client.utils.ComponentUtils;
 import com.jdimension.jlawyer.client.utils.FileConverter;
+import com.jdimension.jlawyer.client.utils.FileChooserUtils;
 import com.jdimension.jlawyer.client.utils.FileUtils;
 import com.jdimension.jlawyer.client.utils.ThreadUtils;
 import com.jdimension.jlawyer.fax.BalanceInformation;
@@ -1117,12 +1118,13 @@ public class SendFaxDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_cmbOwnUrisActionPerformed
 
     private void cmdBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdBrowseActionPerformed
-        JFileChooser chooser = new JFileChooser();
+        JFileChooser chooser = FileChooserUtils.createFileChooser();
         chooser.setMultiSelectionEnabled(false);
         int returnVal = chooser.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
-                this.file=chooser.getSelectedFile();
-                this.txtFile.setText(this.file.toString());
+            FileChooserUtils.rememberDirectory(chooser);
+            this.file=chooser.getSelectedFile();
+            this.txtFile.setText(this.file.toString());
 
         }
     }//GEN-LAST:event_cmdBrowseActionPerformed


### PR DESCRIPTION
## Summary
- add shared `FileChooserUtils` to centralize JFileChooser start-directory handling
- remember the last selected directory for shared dialogs and preserve feature-specific last-directory keys where they already exist
- update common upload/save/select dialogs to use the shared behavior

## Copilot review follow-up
- changed mail and beA attachment save loops to create each chooser via `FileChooserUtils.createFileChooser()` so later attachments pick up the just-remembered directory
- stopped feature-specific chooser keys from updating or falling back through the shared global last-directory key, preserving isolation between workflows
- removed the unused configurable default-directory key from this PR
- stopped synchronous `saveConfiguration()` calls from `rememberDirectory`; settings remain in memory and are persisted by the existing client configuration save path
- tightened fallback and `DIRECTORIES_ONLY` directory detection behavior

## Testing
- `git diff --check HEAD~1 HEAD`
- Attempted: `ant -f j-lawyer-client/build.xml -Dplatforms.JDK_17.home=$JAVA_HOME compile` in a disposable `eclipse-temurin:17-jdk` Docker container
- Current upstream `master` fails client compilation in this container before this patch can be validated fully, due missing BEA REST / Dropscan service classes such as `com.jdimension.jlawyer.services.bea.rest.BeaPostbox` and `DropscanServiceRemote`.