### PR TITLE
backupmgr: fix CVE-2023-22102 (MySQL Connector/J 8.2.0)

### DIFF
--- a/j-lawyer-backupmgr/pom.xml
+++ b/j-lawyer-backupmgr/pom.xml
@@ -38,9 +38,11 @@
             <version>${javafx.version}</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <!-- Renamed coordinate com.mysql:mysql-connector-j; version inherited from the
+                 root dependencyManagement (8.2.0), which fixes CVE-2023-22102. The old
+                 mysql:mysql-connector-java line ended at 8.0.33 (still vulnerable). -->
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/j-lawyer-backupmgr/src/main/java/org/jlawyer/backupmgr/impl/RestoreExecutor.java
+++ b/j-lawyer-backupmgr/src/main/java/org/jlawyer/backupmgr/impl/RestoreExecutor.java
@@ -759,7 +759,7 @@ public class RestoreExecutor {
         }
         Class.forName("com.mysql.cj.jdbc.Driver");
         boolean jlawyerdbFound = false;
-        try (Connection mysql = DriverManager.getConnection("jdbc:mysql://" + this.dbHost + ":" + this.dbPort + "/" + this.dbName + "?user=" + this.dbUser + "&serverTimezone=Europe/Berlin&useSSL=false&password=" + dbPassword)) {
+        try (Connection mysql = DriverManager.getConnection("jdbc:mysql://" + this.dbHost + ":" + this.dbPort + "/" + this.dbName + "?user=" + this.dbUser + "&serverTimezone=Europe/Berlin&sslMode=DISABLED&password=" + dbPassword)) {
             ResultSet rs = mysql.getMetaData().getCatalogs();
 
             while (rs.next()) {


### PR DESCRIPTION
Resolves Dependabot alert #14 (CVE-2023-22102 / GHSA-m6vm-37g8-gqvh, high) in `j-lawyer-backupmgr`.

## Why
backupmgr used `mysql:mysql-connector-java:8.0.28`. The old `mysql:mysql-connector-java`
coordinate has **no fixed release** (it ended at 8.0.33, which is still in the vulnerable
range `<= 8.0.33`); the fix is only published under the renamed coordinate
`com.mysql:mysql-connector-j` **>= 8.2.0**. So neither 8.0.33 nor a same-coordinate bump
clears the alert — the coordinate switch is required.

## Change
- `com.mysql:mysql-connector-j` with **no inline version** → inherits **8.2.0** from the root
  `dependencyManagement` (the version the main reactor already runs). Same driver classes
  (`com.mysql.cj.jdbc.Driver`) → no code change for the rename.
- Restore JDBC URL: `useSSL=false` → `sslMode=DISABLED` (behaviour-equivalent; `useSSL` is
  deprecated in Connector/J 8.x). `serverTimezone=Europe/Berlin` stays pinned.

## Risk / verification
Low-risk: the two upgrade-sensitive connection defaults (timezone, SSL) are pinned
explicitly in the URL, and the main server already runs 8.2.0. **backupmgr targets both older
MySQL and MariaDB — please smoke-test a restore against both** before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)