### PR TITLE
Remove unused glazedlists dependency (fixes critical CVE-2023-31890)

### DIFF
--- a/j-lawyer-client/pom.xml
+++ b/j-lawyer-client/pom.xml
@@ -373,10 +373,6 @@
             <artifactId>bouncy-castle-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.glazedlists</groupId>
-            <artifactId>glazedlists</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jlawyer.thirdparty</groupId>
             <artifactId>jai_codec</artifactId>
             <version>0.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,11 +156,6 @@
                 <version>1.06</version>
             </dependency>
             <dependency>
-                <groupId>com.glazedlists</groupId>
-                <artifactId>glazedlists</artifactId>
-                <version>1.11.0</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>


### PR DESCRIPTION
Resolves Dependabot alert #68 (CVE-2023-31890 / GHSA-p6m6-9j36-vfjx, **critical** — glazedlists XML deserialization).

## Why removal (not a bump)
`com.glazedlists:glazedlists:1.11.0` has **no patched release** (`first_patched: null`), so it can't be upgraded. And it is **completely unused**: the `ca.odell.glazedlists` package is referenced by **0** files (no import, reflection string, or `.form` reference). It was a direct, dead dependency declared in `j-lawyer-client/pom.xml` (+ a version pin in the root BOM) and appeared at top level in the dependency tree (not pulled transitively).

## Change
- Remove the `com.glazedlists:glazedlists` dependency from `j-lawyer-client/pom.xml`.
- Remove its version pin from the root `dependencyManagement`.

No code change — nothing imports it, so compilation is unaffected. A from-scratch build confirms the jar is gone and the build stays green; the critical alert is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)