### PR TITLE
Remove unused Apache Jena / java-rdfa (fixes critical XXE CVE-2021-39239)

### DIFF
--- a/j-lawyer-server/j-lawyer-io/pom.xml
+++ b/j-lawyer-server/j-lawyer-io/pom.xml
@@ -192,31 +192,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.rootdev</groupId>
-            <artifactId>java-rdfa</artifactId>
-            <scope>provided</scope>
-            <!-- java-rdfa 0.4.2 pulls jena-core (-> log4j 1.x + xerces), slf4j-log4j12 and junit
-                 at compile scope; exclude them so they do not bundle / clash with log4j2. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
             <scope>provided</scope>
@@ -277,41 +252,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <scope>provided</scope>
-            <!-- jena-core 2.7.4 drags in log4j 1.x + a second SLF4J binding (slf4j-log4j12) and xercesImpl, none present in the flat-jar model. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-iri</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/j-lawyer-server/j-lawyer-server-ear/pom.xml
+++ b/j-lawyer-server/j-lawyer-server-ear/pom.xml
@@ -146,30 +146,6 @@
             <artifactId>jai-imageio-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.rootdev</groupId>
-            <artifactId>java-rdfa</artifactId>
-            <!-- java-rdfa 0.4.2 pulls jena-core (-> log4j 1.x + xerces), slf4j-log4j12 and junit
-                 at compile scope; exclude them so they do not bundle / clash with log4j2. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
         </dependency>
@@ -190,39 +166,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <!-- jena-core 2.7.4 drags in log4j 1.x + a second SLF4J binding (slf4j-log4j12) and xercesImpl, none present in the flat-jar model. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-iri</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/j-lawyer-server/j-lawyer-server-ejb/pom.xml
+++ b/j-lawyer-server/j-lawyer-server-ejb/pom.xml
@@ -172,31 +172,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.rootdev</groupId>
-            <artifactId>java-rdfa</artifactId>
-            <scope>provided</scope>
-            <!-- java-rdfa 0.4.2 pulls jena-core (-> log4j 1.x + xerces), slf4j-log4j12 and junit
-                 at compile scope; exclude them so they do not bundle / clash with log4j2. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
             <scope>provided</scope>
@@ -258,43 +233,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <scope>provided</scope>
-            <!-- jena-core 2.7.4 drags in log4j 1.x + a second SLF4J binding (slf4j-log4j12)
-                 and xercesImpl, none present in the flat-jar model. Exclude to keep logging on
-                 log4j2/slf4j and avoid a duplicate XML parser. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-iri</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/j-lawyer-server/j-lawyer-server-io/pom.xml
+++ b/j-lawyer-server/j-lawyer-server-io/pom.xml
@@ -175,31 +175,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.rootdev</groupId>
-            <artifactId>java-rdfa</artifactId>
-            <scope>provided</scope>
-            <!-- java-rdfa 0.4.2 pulls jena-core (-> log4j 1.x + xerces), slf4j-log4j12 and junit
-                 at compile scope; exclude them so they do not bundle / clash with log4j2. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
             <scope>provided</scope>
@@ -260,41 +235,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <scope>provided</scope>
-            <!-- jena-core 2.7.4 drags in log4j 1.x + a second SLF4J binding (slf4j-log4j12) and xercesImpl, none present in the flat-jar model. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-iri</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/j-lawyer-server/j-lawyer-server-war/pom.xml
+++ b/j-lawyer-server/j-lawyer-server-war/pom.xml
@@ -175,31 +175,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.rootdev</groupId>
-            <artifactId>java-rdfa</artifactId>
-            <scope>provided</scope>
-            <!-- java-rdfa 0.4.2 pulls jena-core (-> log4j 1.x + xerces), slf4j-log4j12 and junit
-                 at compile scope; exclude them so they do not bundle / clash with log4j2. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
             <scope>provided</scope>
@@ -260,41 +235,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <scope>provided</scope>
-            <!-- jena-core 2.7.4 drags in log4j 1.x + a second SLF4J binding (slf4j-log4j12) and xercesImpl, none present in the flat-jar model. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-iri</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -416,11 +416,6 @@
                 <version>2.1</version>
             </dependency>
             <dependency>
-                <groupId>net.rootdev</groupId>
-                <artifactId>java-rdfa</artifactId>
-                <version>0.4.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>4.4</version>
@@ -467,16 +462,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.4.11</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-core</artifactId>
-                <version>2.7.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-iri</artifactId>
-                <version>0.9.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Resolves the `org.apache.jena:jena-core` alert (CVE-2021-39239, high — XXE).

## Why removal (not the #3444 bump)
`jena-core`, `jena-iri` and `net.rootdev:java-rdfa` are **completely unused**: nothing in the
codebase references `com.hp.hpl.jena`, `org.apache.jena`, `net.rootdev`, RDFa, SPARQL or any
Jena API. They were vendored as direct dependencies during the Ant→Maven migration and never
used. The advisory has no fix in the 2.x/3.x line — only 4.2.0, a 10-year major jump with a
completely different transitive graph (and `java-rdfa:0.4.2` is built against Jena 2.x
`com.hp.hpl.jena.*`, so it would break at runtime under Jena 4.x anyway — though it's never
invoked).

## Change
Remove the three coordinates from the root `dependencyManagement` and the 5 server modules
(ejb/war/io/server-io/ear) — 314 lines, pure deletions. Also drops the migration-era
exclusions that existed only to tame the `java-rdfa → jena` transitive mess (log4j 1.x /
slf4j-log4j12 / xerces / junit). The xerces (odftoolkit) and junit (ws-commons-util)
exclusions and the wildfly-cli `*:*` exclusion are kept.

## Verified
Full build green; EAR `lib/` no longer contains jena/java-rdfa and stays free of
log4j-1.2.x / slf4j-log4j12 / xerces / junit (jena-iri was the real log4j1/slf4j-log4j12
source). Smoke-tested — no functional change (Jena was never used).

Supersedes #3444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)