### PR TITLE
docs(openspec): proposal for document encryption at rest

### DIFF
--- a/openspec/changes/add-document-encryption-at-rest/design.md
+++ b/openspec/changes/add-document-encryption-at-rest/design.md
@@ -1,0 +1,367 @@
+# Design: Encryption at Rest for Case Documents and Previews
+
+## Context
+
+Document bytes for cases are stored under the data directory
+(`jlawyer.server.basedirectory`, default `/opt/jboss/j-lawyer-data/`):
+
+```
+<basedirectory>/
+├── archivefiles/<archiveFileId>/<documentId>          # originals + versions (raw bytes)
+├── archivefiles-preview/<archiveFileId>/<documentId>.text   # extracted text for search
+│                                       /<documentId>.pdf    # rendered PDF preview
+├── searchindex/                                       # Lucene index (extracted plaintext)
+├── templates/ emailtemplates/ mastertemplates/        # templates
+```
+
+All document content I/O funnels through three static methods in
+`com.jdimension.jlawyer.server.utils.ServerFileUtils`
+(`readFile(File)`:814, `writeFile(File,byte[])`:850, `createFile(String,byte[])`:857),
+invoked from `ArchiveFileService` (`addDocumentImpl`:~1805, `setDocumentContent`:~2127,
+`getDocumentContentImpl`:~2321) and `PreviewGenerator`. The storage location may be a
+local disk or a `VirtualFile` backend (Samba/SFTP/FTP) — encryption is applied to the
+byte payload **above** the storage layer, so it protects remote backends too.
+
+### Scope Boundary (by storage path, not content type) — Q5
+
+Encryption scope is defined by **where bytes are written**, not by content type. Every
+document under `archivefiles/` is in scope regardless of kind, because they all flow
+through the same `addDocumentImpl`/`getDocumentContent` byte[] path:
+- **Dictation/audio** are ordinary documents — `dictateSign` is only a metadata field on
+  `ArchiveFileDocumentsBean` (`ArchiveFileService.java:1811`); the audio bytes are stored
+  at `archivefiles/<id>/<docId>` like any other document. **No special handling.**
+- **Saved e-mails** (`.eml`) are likewise saved as documents under `archivefiles/`; there
+  is no separate on-disk e-mail store (live mail stays on the IMAP server).
+
+Sibling folders under `basedirectory` and their disposition:
+- `archivefiles/`, `archivefiles-preview/` → **in scope** (C2).
+- `searchindex/` (Lucene) → out of scope, accepted residual risk (C2).
+- `emailtemplates/`, `mastertemplates/`, `letterheads/` → templates, out of scope.
+- `faxqueue/` → transient outbound-fax spool; may briefly hold document content as
+  plaintext. Out of scope, noted as a minor transient residual (not one of the two
+  named folders).
+- `databucket/` temp transfers live under `java.io.tmpdir` and are handled by C5.
+
+An existing `com.jdimension.jlawyer.security.Crypto` performs AES-256-GCM but with a
+**hard-coded salt and a fixed nonce** (`Crypto.java:685-699`) and a string-only API.
+A fixed GCM nonce reused across many files breaks confidentiality and integrity, so
+`Crypto` is unsuitable for file content and a new primitive is required.
+
+## Goals / Non-Goals
+
+**Goals**
+- Confidentiality + integrity of `archivefiles/` and `archivefiles-preview/` content
+  on the storage medium (defends against stolen disk/backup/snapshot and read access
+  to the storage backend).
+- Transparent to all readers/writers: REST (v1–v7), EJB clients, search indexing,
+  preview/OCR/PDF generation behave identically for authenticated users.
+- Switchable on without a flag day (mixed encrypted/plaintext coexistence).
+- Safe, resumable migration both directions; cheap key rotation.
+
+**Non-Goals**
+- Protecting against a fully compromised running server that already holds the
+  unlocked key in memory (live-memory attacker). At-rest ≠ in-use protection.
+- Per-user / per-case cryptographic access control (server must decrypt for
+  search/preview, so a single firm-wide key domain is assumed unless decided otherwise).
+- Encrypting the Lucene index, the database, or templates (residual risk; see below).
+- End-to-end / client-side encryption.
+
+## Decisions
+
+Confirmed with the product owner (2026-06-22):
+- **C1 Key source:** firm-wide master **key file on the server**, stored outside the
+  data directory with restrictive file permissions; unlocked automatically at startup
+  (unattended restarts supported). Threat model: protects against stolen
+  disk/backup/snapshot and read access to the storage backend — **not** against an
+  attacker who already has live access to the running server's memory.
+- **C2 Scope:** encrypt **only** `archivefiles/` and `archivefiles-preview/`. The
+  Lucene `searchindex/` stays plaintext — an **accepted residual risk** (extracted
+  text recoverable with disk access). DB and templates are out of scope.
+- **C3 Key domain:** a **single firm-wide key domain** (one master key + per-file
+  data keys via envelope). The server can decrypt for search/preview/OCR.
+- **C4 Migration:** **administrator-triggered, resumable, online batch** migration,
+  **with** reverse migration (decrypt-all) and key rotation supported.
+- **C6 Keystore provisioning + export via the client (and REST):** symmetric upload/
+  download of the existing keystore.
+  - **Upload:** a server missing its key (e.g. after migration to a new host — the key is
+    intentionally outside `basedirectory` and the backup, per C1) is unlocked by a
+    `sysAdminRole` **uploading the backed-up keystore**; the server writes it to the
+    configured location (`chmod 600`) and unlocks the document subsystem.
+  - **Download/export:** a `sysAdminRole` can **download the keystore** — this is the
+    mechanism that produces the off-server backup the Q3 gate requires. Offered when new
+    key material is created (initial activation and rotation) and on demand thereafter.
+    Note: after rotation the old backup no longer decrypts the re-wrapped data, so the new
+    key must be downloaded and its backup confirmed as part of completing rotation.
+  - Both directions are only a transport for the existing key — no new key-derivation
+    scheme. Hard conditions: `sysAdminRole` only, audited, **TLS/HTTPS required** (raw key
+    bytes on the wire), key bytes never logged; upload additionally **validates the key
+    matches the data** (fingerprint / test-unwrap) and performs **no silent overwrite**
+    (explicit replace required). A passphrase-based recovery keyslot was considered and
+    **rejected** — it would add an offline brute-force surface and, if the wrapper
+    travelled in the backup, weaken the C1 stolen-backup guarantee.
+- **C5 DataBucket path:** the `DataBucket` streaming path
+  (`getDocumentContentBucket`, `ArchiveFileService.java:5875`) **must** be supported.
+  Today it `Files.copy`s the source file into a temp bucket file under
+  `java.io.tmpdir/databucket/<id>` and `DataBucketUtils.fillBucket`/`nextBucket` then
+  serve chunks from it via `RandomAccessFile`. With encryption on, the server decrypts
+  the source file **server-side into the temp bucket file** (streaming GCM decrypt so a
+  large file is not held wholly in memory), and the existing chunked bucket reads serve
+  the resulting **plaintext** unchanged. Consequence: the temp bucket file is plaintext
+  on the server's temp dir for the lifetime of the transfer — same exposure as today
+  (the temp copy is already plaintext) — and must be reliably removed
+  (`removeLocalFile`/`removeStaleBuckets`) after transfer. A symmetric path applies if
+  buckets are ever used for uploads (decrypt-on-read / encrypt-on-assemble).
+
+## Design Notes (recommended technical defaults)
+
+- **D1 Algorithm:** AES-256-GCM, **fresh random 96-bit IV per file**, 128-bit auth
+  tag. AES-NI/ARMv8-crypto makes this multi-GB/s; negligible for typical KB–MB docs.
+- **D2 Envelope encryption:** each file gets a random data key (DEK); the DEK is wrapped
+  by a firm-wide master key (KEK). Stored as a per-file header so key rotation only
+  re-wraps DEKs (no bulk re-encryption of content).
+- **D3 On-disk format:** `magic | version | algoId | wrappedDEK | IV | ciphertext+tag`.
+  The magic prefix lets `read` auto-detect encrypted vs. plaintext files → enables
+  mixed-state coexistence and idempotent migration.
+- **D4 Injection point:** a dedicated document-storage helper (or a scoped wrapper),
+  **not** blanket encryption inside `ServerFileUtils` — only paths under
+  `archivefiles/` and `archivefiles-preview/` are encrypted, leaving templates and
+  other `ServerFileUtils` callers untouched.
+- **D5 Fail-closed:** if the feature is enabled but the key is missing/invalid at
+  startup, document read/write fails loudly rather than silently serving/over-writing.
+- **D6 Key derivation:** KEK derived with PBKDF2WithHmacSHA512 (or Argon2 if a lib is
+  acceptable) from the configured secret with a **random per-install salt** stored
+  alongside the wrapped master key — never the hard-coded salt from `Crypto`.
+
+## Risks / Trade-offs
+
+- **Key loss = total data loss.** No key escrow → unrecoverable documents. Mitigation:
+  mandatory documented key backup, refuse to start migration until the operator
+  confirms a key backup exists.
+- **Large-file memory pressure.** The plain `readFile` loads whole files into a `byte[]`
+  (2 GB cap); GCM verifies the tag over the full content anyway, so big scans (100s of
+  MB) double memory transiently on that path. The `DataBucket` path avoids this by
+  streaming-decrypting to a temp file (C5). Note: streaming GCM only surfaces verified
+  plaintext after the tag is checked at stream end — acceptable here because the temp
+  bucket file is server-local and removed after transfer.
+- **Migration window.** Encrypting an existing multi-GB data directory is IO/CPU-heavy
+  and must be resumable, idempotent (header detection), and online (no downtime).
+- **Backups become ciphertext.** Good for at-rest, but `j-lawyer-backupmgr` restores
+  are useless without the key → backup/restore docs must cover key handling.
+- **Residual plaintext leaks outside scope:** the Lucene index and `.text` previews
+  contain extracted document text; the DB holds metadata. If the index stays plaintext,
+  an attacker with disk access can still recover substantial text. Must be an explicit,
+  accepted decision.
+- **Performance:** symmetric AES-GCM cost is small, but **per-key PBKDF2 must run once
+  at startup**, never per file. Preview/OCR/PDF still need plaintext in memory.
+- **Nextcloud share leaves the encryption boundary (Q14).** Sharing a document to
+  Nextcloud transfers it **unencrypted** — by design. This is only safe if the cloud
+  sync obtains content through the decrypting service layer
+  (`ArchiveFileService.getDocumentContent`), **not** by reading raw files off disk. If
+  any cloud/external path reads the data directory directly, it would now get
+  ciphertext and break. Action: verify the cloud-sync read path and document that the
+  Nextcloud copy is plaintext, governed by Nextcloud's own at-rest protection.
+
+## Migration Sizing (Q9)
+
+Typical data directory: **20–150 GB**. Forward migration reads every file once and
+rewrites it once, so it is **I/O-bound, not CPU-bound**: AES-256-GCM with AES-NI runs at
+multiple GB/s, negligible next to disk throughput. Rough total I/O ≈ 2× data size
+(40–300 GB read+write).
+
+- On HDD-class storage (~100 MB/s effective) that is ~7–50 min of pure transfer; on
+  SSD/NVMe, minutes. Real runtime is usually dominated by **IOPS / per-file overhead**
+  (legal data is many small PDFs/text previews), so plan for longer than raw-throughput
+  math suggests and report progress + ETA rather than promising a fixed window.
+- Implications baked into the design:
+  - **Online & resumable** (already required) — no maintenance window for 150 GB.
+  - **Crash-safe in-place rewrite**: encrypt to a temp file in the same directory,
+    fsync, then atomic rename over the original, so an interrupted file is never left
+    half-written; header detection makes re-runs idempotent.
+  - **Throttling**: allow the operator to bound migration I/O (e.g. run off-hours /
+    limited rate) so a 150 GB run does not starve live document access.
+  - **No extra steady-state cost**: per-document crypto overhead at runtime is marginal;
+    expected overhead budget is < ~5% added latency per op (AES-NI assumed, see Q10).
+
+## Migration Plan
+
+1. Ship the crypto + storage layer first, **disabled by default**; reads auto-detect
+   so deploying the code changes nothing until enabled.
+2. Operator initializes the key, backs it up, and **proves the backup at activation** by
+   entering the key fingerprint/recovery code (Variant B). This gate fires before the
+   first key-dependent operation — enabling encrypted writes or starting migration,
+   whichever comes first — not only before migration.
+3. Admin triggers forward migration: walk `archivefiles/` + `archivefiles-preview/`,
+   encrypt-in-place any plaintext file (skip already-encrypted via header), resumable
+   with progress + audit log. New writes are encrypted immediately once enabled.
+4. Rollback: reverse migration decrypts in place and the feature can be disabled.
+5. Key rotation: re-wrap DEKs from old KEK to new KEK (fast, content untouched).
+
+## Key Storage, Document Metadata & Initialization
+
+Answers to the architecture follow-ups (these refine C1; they do not change the
+confirmed decisions).
+
+### Where the key / keystore (password) lives
+With C1 (auto-unlock, key on the server) two concrete shapes are viable:
+- **(a) Raw key file** — a 256-bit KEK in a file **outside `basedirectory`** (e.g.
+  `/opt/jboss/j-lawyer-keys/` or WildFly `standalone/configuration/`), `chmod 600`,
+  owned by the WildFly OS user. No separate password; the protection *is* the
+  filesystem ACL.
+- **(b) Java KeyStore (PKCS12)** holding the KEK, protected by a keystore password. The
+  password must then be readable at startup — a WildFly **system property / env var**
+  (e.g. `jlawyer.encryption.keystore.password` set in `standalone.conf` / a Docker or
+  systemd secret), itself permission-protected.
+
+Honest crux for unattended restart: on a single host the keystore password cannot be
+guarded by another *independent* secret — it bottoms out at OS file permissions either
+way. So (a) and (b) are roughly equal on one host; (b) only adds value if the password
+is injected at boot from somewhere a disk thief does not also get. **Recommendation:**
+option (a) (or (b) with the password in an env var), key located **outside the data
+directory** and **excluded from document backups**. Threat model restated precisely:
+this defends **stolen backups of the data directory** (key not in the backup) and
+**detached/remote storage backends** (Samba/SFTP/FTP hold only ciphertext, key stays on
+the app server). It does **not** defend a full-host compromise or a full-disk theft that
+captures both the data dir *and* the key location.
+
+### Keystore location per OS (server host)
+The keystore lives on the **server** (WildFly), not the client (the client only saves a
+*downloaded* backup wherever the admin chooses). The path is configurable via the
+server setting (task 4.1); recommended defaults, always **outside `basedirectory`**, with
+restrictive permissions, and **excluded from backups**:
+- **Linux:** `/etc/j-lawyer-server/keystore/keystore.p12` (alt. `/opt/jboss/j-lawyer-keys/`);
+  dir `700`, file `600`, owned by the WildFly service user.
+- **Windows:** `C:\ProgramData\j-lawyer\keystore\keystore.p12`; ACL limited to the service
+  account + Administrators.
+- **macOS:** `/Library/Application Support/j-lawyer/keystore/keystore.p12`; `600`, service
+  user. (The macOS Keychain is user-scoped and unsuitable for a headless daemon.)
+- **Docker:** a dedicated mounted volume or Docker secret, **not** under the data volume
+  (`/var/docker_data/j-lawyer-data/` → `/opt/jboss/j-lawyer-data/`, which is created
+  `chmod -R 777`). Must persist across container recreation and stay out of the data
+  backup.
+
+### Source of truth for "is this file encrypted?"
+The **per-file header is authoritative** (D3): encryption state is determined by reading
+the file's magic bytes, which is what makes mixed-state coexistence and idempotent,
+resumable migration work — and it is robust if the DB and files ever diverge (e.g.
+restore from mismatched backups). Crucially, `archivefiles-preview/` files have **no DB
+row**, so they can only rely on the header. Therefore **all crypto material lives in the
+file header**, never in the DB:
+`magic | formatVersion | algoId(AES-256-GCM) | keyVersion | wrappedDEK | iv | ciphertext+tag`.
+
+### Per-document DB attributes (case_documents)
+The header is sufficient for correctness, so the DB needs only **lightweight bookkeeping
+hints** (denormalised, kept in sync on write/migrate, never the source of truth) to power
+migration progress and "how many docs still plaintext?" queries without scanning files:
+- `encryption_state` (e.g. `NONE` / `ENCRYPTED`) — migration bookkeeping.
+- `key_version` (INT) — which KEK generation wrapped this file (rotation reporting;
+  authoritative copy is in the header).
+- **`size` semantics unchanged**: keeps meaning the **logical plaintext length** clients
+  expect, *not* the larger on-disk ciphertext (header + tag). Implementation must report
+  plaintext size even though the file on disk is bigger.
+- No new columns for the `.text`/`.pdf` previews (they have no row) — header only.
+
+Caveat: the legacy `content MEDIUMBLOB` column can still hold document bytes for
+not-yet-`migrateDocument`- d records. Bytes living in the DB blob are **out of scope** for
+file-at-rest encryption (that is DB-level encryption); ensure content is file-based, or
+document the residual.
+
+### Where the "encryption is active" state lives — three separate stores
+1. **Config / intent** — the `encryption enabled` flag and key-source config live in the
+   server-wide `server_settings` table (the existing key/value store accessed via
+   `SystemManagement.getSetting/setSetting` + `ServerSettingsKeys`, e.g.
+   `jlawyer.server.encryption.enabled`; absent/false ⇒ off). It drives whether new writes
+   encrypt and whether fail-closed applies, and it travels with the DB backup.
+2. **Actual per-file data state** — authoritative in the **file header**; the
+   `encryption_state`/`key_version` columns on `case_documents` are only denormalised
+   hints. The "enabled" flag does **not** imply every file is encrypted (mixed-state /
+   partial migration); the header is the truth per file.
+3. **Key + key metadata** — the KEK, key version, KDF salt and fingerprint live in the
+   keystore file **outside `basedirectory`**, not in the DB, excluded from backups.
+
+This separation is exactly what produces the migrated/locked case: after a move the DB
+flag says "enabled" but the key file is absent ⇒ scoped fail-closed (Q12) ⇒ offer the
+keystore upload (C6).
+
+### Initial key/keystore creation — NOT a Flyway migration
+Key generation must **not** run inside a Flyway migration, because Flyway runs
+automatically at deploy for *every* install while the feature default is **off** —
+silently generating keys or enabling crypto would be wrong, and key material is
+filesystem/server state, not schema state. Split it:
+- **Flyway SQL migration** (`V<maj>_<min>_<patch>_<seq>__AddDocumentEncryptionColumns.sql`)
+  adds only the two bookkeeping columns to `case_documents`. Pure schema, safe and inert
+  when the feature is off; runs everywhere.
+- **Key/keystore creation is an explicit, audited admin action** ("Initialize
+  encryption"): generate a random 256-bit KEK via `SecureRandom`, write the key
+  file/keystore to the configured location with restrictive permissions, persist key
+  metadata (key version, per-install KDF salt if a passphrase-derived KEK is used)
+  **alongside the key — outside the DB and outside backups**, refuse to overwrite an
+  existing key, and require the operator's key-backup confirmation (Q3) before any
+  forward migration may start.
+
+## Admin Control Surface
+
+Authorization: every encryption administration operation is restricted to the
+**`sysAdminRole`** (not the ordinary `adminRole`) — `@RolesAllowed({"sysAdminRole"})` on
+the EJB operations, the same role `SystemManagement` already uses for sensitive actions.
+This holds for both the client and REST surfaces.
+
+All administrator operations — enabling/disabling encryption, the key-backup
+confirmation (Q3), keystore upload (C6), forward migration, reverse migration, and key
+rotation — are **triggered from the client** and **executed on the server**. This follows
+the existing long-running-admin-op pattern: the "Suchindex neu erfassen" button in
+`SearchIndexOptionsDialog` (`j-lawyer-client/.../configuration/SearchIndexOptionsDialog.java`)
+which calls a server service and lets the work proceed server-side.
+
+- A new admin dialog (under `AdminConsoleFrame`, alongside `ServerSettings` /
+  `SearchIndexOptionsDialog`) hosts the controls; `.form` files kept in sync for the GUI
+  builder.
+- The client is only the control/monitoring UI. Migration/rotation/decryption run on the
+  server (it holds both the data and the key) as background jobs that **survive client
+  disconnect** and report progress/status the client can poll — consistent with the
+  resumable/online migration requirement.
+- **Headless availability via REST (Q15 → yes):** the same operations are also exposed
+  over the REST API (latest version **v8**) so server-only/Docker installations can be
+  administered without the desktop client. Both surfaces call the same server operations.
+  Model: `AdministrationEndpointV7` already provides the right template — a `/backup`
+  POST plus async `/jobs/{jobId}/status` and `/jobs/list` endpoints via
+  `SingletonService`; the encryption endpoints reuse that kick-off-then-poll job pattern.
+  Admin-only (HTTP Basic), **HTTPS required** for the keystore-upload endpoint (raw key
+  bytes on the wire), never logged. New endpoints only — existing versions unchanged; the
+  served `swagger.json` is regenerated and re-baselined.
+
+## Compliance Drivers (Q13)
+
+Confirmed drivers: **DSGVO** and the German attorney confidentiality regime
+(**BRAO / StGB**).
+- **DSGVO Art. 32** ("state of the art" technical/organisational measures) and Art. 5(2)
+  (accountability) — satisfied by AES-256-GCM at rest plus audit logging of bulk crypto
+  operations. Art. 33/34 breach exposure is reduced because a stolen disk/backup yields
+  only ciphertext.
+- **Attorney confidentiality**: StGB §203 (Verletzung von Privatgeheimnissen) and the
+  BRAO/BORA confidentiality duties make unauthorised disclosure of client documents a
+  professional and criminal-law risk; encryption at rest is a proportionate safeguard.
+- No specific cipher/key length is mandated by these; **AES-256-GCM with per-file random
+  IV is comfortably within state of the art**, so no algorithm change is forced.
+
+## Open Questions
+
+Resolved: Q1, Q2, Q4, Q6, Q7 → C1–C4; Q8 → C5; Q9 (size 20–150 GB, ~5% overhead OK) →
+Migration Sizing; Q10 (AES-NI may be assumed) → yes; Q11 (default **off** for new
+installs and upgrades) → see config requirement; Q13 (DSGVO + BRAO/StGB) → Compliance
+Drivers; Q14 (Nextcloud share sends plaintext) → see Risks + task 6.4; Q5 → see Scope
+Boundary (no separate dictation/audio or e-mail store exists).
+
+Resolved: Q3 → the key-backup gate fires at **activation** (first dependency on the key:
+enabling encrypted writes **or** starting migration, whichever first), and confirmation
+uses **Variant B** — the admin must type the key fingerprint/recovery code derived from
+the actual key material (not a mere checkbox).
+
+Resolved: Q12 → **Option A, scoped fail-closed**. On missing/invalid key the document
+subsystem fails closed (read+write refused, never plaintext-fallback or raw-ciphertext),
+while the rest of the application keeps running; a startup check surfaces a loud
+error/health warning and keeps document functions disabled rather than appearing healthy.
+
+Resolved: Q15 → **yes**, the admin operations are also exposed over the REST API (v8),
+backed by the same server operations as the client (see Admin Control Surface).
+
+All design questions are now resolved; the proposal is ready for review.

--- a/openspec/changes/add-document-encryption-at-rest/proposal.md
+++ b/openspec/changes/add-document-encryption-at-rest/proposal.md
@@ -1,0 +1,84 @@
+# Change: Encryption at Rest for Case Documents and Previews
+
+## Why
+
+Case documents are the most sensitive data the system holds (attorney-client
+privileged material, German DSGVO Art. 9 special-category data, etc.). Today the
+contents of the `archivefiles/` (originals/versions) and `archivefiles-preview/`
+(extracted text + rendered PDF previews) folders under the data directory
+(`jlawyer.server.basedirectory`, default `/opt/jboss/j-lawyer-data/`) are stored
+as **plaintext** on disk. Anyone with access to the filesystem, a stolen disk, a
+backup archive, a snapshot, or the underlying Samba/SFTP/FTP storage backend can
+read every document without authenticating to the application.
+
+Encryption at rest closes that gap: the bytes on the storage medium become
+unreadable without the firm's key, supporting DSGVO Art. 32 ("state of the art"
+technical measures) and common law-firm/insurer security requirements — while
+keeping the application's behaviour (search, preview, OCR, REST/EJB access)
+unchanged for authenticated users.
+
+## What Changes
+
+- **NEW capability `document-encryption`**: transparent, authenticated encryption
+  of all bytes written to and read from the `archivefiles/` and
+  `archivefiles-preview/` folders, applied at the document-storage layer so that
+  business logic, REST endpoints, search indexing and preview generation are
+  unaffected.
+- A new **per-file AES-256-GCM** crypto primitive with a **random IV/nonce per
+  file** and a self-describing, versioned **on-disk file header** (magic bytes,
+  format version, algorithm id, IV, wrapped key, auth tag). The existing
+  `Crypto` class is **not** reused for file content because it pins a fixed salt
+  *and* a fixed GCM nonce (catastrophic for multi-file reuse).
+- **Envelope key management**: documents are encrypted with data-encryption keys
+  protected by a master key-encryption key (KEK) that is unlocked at server
+  startup. The KEK source (key file / passphrase / env / external KMS) is a
+  decision captured in `design.md` and surfaced to the operator.
+- **Mixed-state coexistence**: encrypted and plaintext files may live side by
+  side; reads auto-detect via the header so the feature can be switched on
+  without a flag day.
+- **Migration tooling** (admin-triggered, resumable, progress-reporting):
+  - forward migration unencrypted → encrypted,
+  - reverse migration / decrypt-all (rollback and "turn the feature off"),
+  - key rotation by re-wrapping data keys (no bulk re-encryption).
+- **Keystore provisioning + export via the client**: a sysAdmin can **download** the
+  keystore (at activation/rotation and on demand) to create the required off-server
+  backup, and **upload** it to unlock a migrated/rebuilt server missing its key — without
+  filesystem/shell access (TLS-secured, sysAdminRole-only, upload validated + no silent
+  overwrite).
+- **Operational safeguards**: fail-closed when the key is missing/invalid,
+  mandatory key-backup/escrow guidance, and audit logging of bulk
+  encrypt/decrypt/rotate operations.
+- **Configuration**: a server setting enables/disables the feature and selects
+  the key source; defaults chosen to avoid breaking existing installs.
+- **Admin surfaces**: all operations (enable/disable, key-backup confirmation, keystore
+  upload, forward/reverse migration, key rotation, status) are triggered from the client
+  admin console **and** exposed over the REST API (v8) so server-only/Docker
+  installations can be administered headless; both surfaces call the same server
+  operations.
+
+Scope is defined by storage path, not content type: **all** documents under
+`archivefiles/` are covered regardless of kind — including dictation/audio and saved
+e-mails, which are ordinary documents on that path (no separate dictation or e-mail
+store exists). Out of scope (documented as residual risk in `design.md`): the Lucene
+`searchindex/` (extracted plaintext text), the MySQL database contents, the template
+folders (`emailtemplates/`/`mastertemplates/`/`letterheads/`), the transient
+`faxqueue/`, and transport encryption (already handled by TLS).
+
+## Impact
+
+- Affected specs: `document-encryption` (new).
+- Affected code:
+  - `j-lawyer-server-common`: new `com.jdimension.jlawyer.security.*` file-crypto
+    utility + key provider; `ServerFileUtils` (`readFile`/`writeFile`/`createFile`,
+    `ServerFileUtils.java:814,850,857`) — encryption must be scoped to the two
+    document folders, **not** applied to all `ServerFileUtils` callers.
+  - `j-lawyer-server-ejb`: `ArchiveFileService` document I/O
+    (`addDocumentImpl`, `setDocumentContent`, `getDocumentContentImpl`,
+    `getDocumentContentBucket`, preview read/write) and `PreviewGenerator`.
+  - Admin/config surface for enablement, key source, and the migration/rotation
+    operations (EJB service + likely a client admin panel).
+  - `j-lawyer-backupmgr`: backups will contain ciphertext; restore requires the
+    key — key backup/restore semantics must be documented.
+- Affected operators: key management is now a hard operational dependency —
+  **losing the key means losing all documents.** Migration of large existing
+  data directories is a one-time, IO/CPU-intensive batch job.

--- a/openspec/changes/add-document-encryption-at-rest/specs/document-encryption/spec.md
+++ b/openspec/changes/add-document-encryption-at-rest/specs/document-encryption/spec.md
@@ -1,0 +1,389 @@
+## ADDED Requirements
+
+### Requirement: Transparent Encryption of Document Content at Rest
+
+When encryption at rest is enabled, the system SHALL encrypt all byte content
+written to the `archivefiles/` folder (document originals and versions) before it is
+persisted to the storage backend, and SHALL decrypt it transparently on read, so that
+EJB clients, REST API consumers (v1–v7), search indexing, and preview generation
+observe the same plaintext content as before.
+
+#### Scenario: New document is stored encrypted
+- **WHEN** encryption is enabled and a document is added or its content is updated
+- **THEN** the bytes persisted under `archivefiles/<archiveFileId>/<documentId>` are
+  ciphertext and cannot be interpreted without the firm's key
+- **AND** a subsequent authenticated read returns the original plaintext bytes
+
+#### Scenario: Reads are transparent to callers
+- **WHEN** an authenticated caller retrieves document content via EJB or REST
+- **THEN** the returned bytes are identical to the bytes originally stored
+- **AND** no caller code outside the storage layer needs to change
+
+#### Scenario: Chunked DataBucket transfer serves decrypted content
+- **WHEN** an encrypted document is retrieved via the chunked `DataBucket` transfer path
+- **THEN** the server decrypts the document into the local bucket file before chunking,
+  without loading the entire document into memory at once
+- **AND** the client receives the same plaintext chunks it would have received before
+  encryption was enabled
+- **AND** the temporary decrypted bucket file is removed after the transfer completes
+
+### Requirement: Transparent Encryption of Document Previews
+
+When encryption at rest is enabled, the system SHALL encrypt the extracted-text
+(`<documentId>.text`) and rendered-PDF (`<documentId>.pdf`) preview files written to
+the `archivefiles-preview/` folder, and SHALL decrypt them transparently wherever
+previews are consumed.
+
+#### Scenario: Preview generation writes ciphertext
+- **WHEN** a text or PDF preview is generated for a document
+- **THEN** the preview file persisted under `archivefiles-preview/` is ciphertext
+- **AND** displaying the preview to an authenticated user yields the original content
+
+### Requirement: Authenticated Per-File Encryption
+
+The system SHALL encrypt each file with AES-256 in an authenticated mode (GCM) using a
+cryptographically random initialization vector generated independently for every file
+and every rewrite. The system SHALL NOT reuse a fixed nonce/IV across files, and SHALL
+NOT reuse the legacy `Crypto` fixed-salt/fixed-nonce primitive for file content. On
+read, the system SHALL verify the authentication tag and SHALL refuse to return content
+that fails integrity verification.
+
+#### Scenario: Each file uses a unique IV
+- **WHEN** two documents (or two versions of one document) are encrypted
+- **THEN** each is encrypted with its own distinct random IV
+
+#### Scenario: Tampered ciphertext is rejected
+- **WHEN** an encrypted file's bytes have been modified on disk
+- **THEN** the read fails with an integrity error and no plaintext is returned
+
+### Requirement: Self-Describing Versioned File Format
+
+Encrypted files SHALL begin with a self-describing header containing a magic marker, a
+format version, an algorithm identifier, the wrapped data key, and the IV, such that the
+system can (a) detect whether any given file is encrypted or plaintext and (b) evolve
+the format in future versions without ambiguity.
+
+#### Scenario: Encrypted file is detected by header
+- **WHEN** the system opens a file that carries the encryption magic marker
+- **THEN** it decrypts the file using the parameters declared in the header
+
+#### Scenario: Format version is recorded
+- **WHEN** an encrypted file is written
+- **THEN** its header records the format version and algorithm used to produce it
+
+#### Scenario: Crypto material is self-contained in the file
+- **WHEN** an encrypted file is written
+- **THEN** the wrapped data key, IV, algorithm, and key version are stored in the file
+  header itself, so the file can be decrypted with only the master key and without any
+  database record
+- **AND** preview files under `archivefiles-preview/` (which have no database row) are
+  decryptable from their header alone
+
+### Requirement: Logical Size Reported Independently of Ciphertext
+
+The system SHALL continue to report the logical plaintext size of a document to callers,
+not the larger on-disk size that results from the encryption header and authentication
+tag.
+
+#### Scenario: Plaintext size is preserved
+- **WHEN** a client queries the size of an encrypted document
+- **THEN** the size returned equals the original plaintext byte length
+- **AND** not the larger size of the encrypted file on disk
+
+### Requirement: Envelope Key Management with a Master Key
+
+The system SHALL protect each file's data-encryption key by wrapping it with a
+firm-wide master key (key-encryption key) that is unlocked at server startup from a
+configured key source. The master key SHALL be derived/stored using a random per-install
+salt (never a hard-coded salt). The plaintext master key SHALL only exist in server
+memory while the server is running.
+
+#### Scenario: Master key unlocked at startup
+- **WHEN** the server starts with encryption enabled and a valid key source
+- **THEN** the master key is unlocked and document encryption/decryption is available
+
+#### Scenario: Data keys are wrapped, not stored in clear
+- **WHEN** a file is encrypted
+- **THEN** its data-encryption key is stored only in wrapped (encrypted) form
+
+### Requirement: Mixed-State Coexistence
+
+The system SHALL support a data directory that contains both encrypted and plaintext
+document/preview files simultaneously, choosing decrypt-or-passthrough per file based on
+the file header, so that enabling encryption does not require a synchronized flag-day
+conversion of all existing files.
+
+#### Scenario: Plaintext legacy file read after enabling encryption
+- **WHEN** encryption is enabled but a given legacy file has not yet been migrated
+- **THEN** the system detects it is plaintext and returns it unchanged
+
+#### Scenario: Newly written file is encrypted while legacy files remain plaintext
+- **WHEN** encryption is enabled and an existing case gets a new document
+- **THEN** the new file is encrypted while untouched legacy files remain readable
+
+### Requirement: Migration from Unencrypted to Encrypted
+
+The system SHALL provide an administrator-triggered migration that encrypts existing
+plaintext files under `archivefiles/` and `archivefiles-preview/` in place. The
+migration SHALL be idempotent (skipping already-encrypted files via header detection),
+resumable after interruption, performable while the system is online, and SHALL report
+progress and completion.
+
+#### Scenario: Forward migration encrypts legacy files
+- **WHEN** an administrator starts the forward migration
+- **THEN** every plaintext document and preview file becomes encrypted
+- **AND** already-encrypted files are skipped
+
+#### Scenario: Migration resumes after interruption
+- **WHEN** the migration is interrupted and restarted
+- **THEN** it continues without re-processing already-encrypted files and without
+  corrupting partially processed files
+
+### Requirement: Reverse Migration and Key Rotation
+
+The system SHALL provide an administrator-triggered reverse migration that decrypts all
+files back to plaintext (to disable the feature or recover), and SHALL provide key
+rotation that re-wraps existing data keys under a new master key without re-encrypting
+file content.
+
+#### Scenario: Reverse migration decrypts all files
+- **WHEN** an administrator runs the reverse migration with the correct key
+- **THEN** all encrypted files are rewritten as plaintext and the feature can be disabled
+
+#### Scenario: Key rotation re-wraps without bulk re-encryption
+- **WHEN** an administrator rotates the master key
+- **THEN** each file's wrapped data key is re-wrapped under the new master key
+- **AND** the file content ciphertext is not rewritten
+
+### Requirement: Scoped Fail-Closed on Missing or Invalid Key
+
+The system SHALL fail closed when encryption is enabled but the master key is
+unavailable or invalid: it SHALL refuse document read and write operations with a clear
+error rather than serving ciphertext as if it were plaintext or overwriting encrypted
+files with unencrypted data. The failure SHALL be **scoped to the document subsystem** —
+the rest of the application (calendar, contacts, case metadata, invoicing, etc.) SHALL
+continue to operate. The system SHALL NOT fall back to writing plaintext or returning
+raw ciphertext under any circumstances.
+
+At startup, when encryption is enabled but no valid master key is available, the system
+SHALL surface a loud error/health warning and keep the document functions disabled
+(failing closed) rather than starting as if document storage were healthy.
+
+#### Scenario: Server with wrong key does not corrupt data
+- **WHEN** encryption is enabled but the configured key is wrong or missing
+- **THEN** document read and write operations fail with an explicit error
+- **AND** no encrypted file is overwritten or served as raw ciphertext
+
+#### Scenario: Rest of the application stays available
+- **WHEN** the master key is unavailable at runtime
+- **THEN** document operations fail closed
+- **AND** non-document functions (calendar, contacts, case metadata, invoicing) remain
+  usable
+
+#### Scenario: Startup with enabled encryption but no valid key
+- **WHEN** the server starts with encryption enabled but cannot load a valid master key
+- **THEN** it raises a visible error/health warning and leaves document functions
+  disabled
+- **AND** it does not serve or write document content as plaintext
+
+### Requirement: Key Backup Safeguard at Activation
+
+The system SHALL require a confirmed key backup before the first moment any document
+becomes dependent on the master key — that is, before encrypted writes are activated
+**or** before a forward migration starts, whichever occurs first — and SHALL document
+that loss of the key makes all encrypted documents permanently unrecoverable. The
+confirmation SHALL NOT be a simple acknowledgement: the administrator SHALL be required
+to enter a key fingerprint (or recovery code) displayed from the actual key material, so
+that the confirmation proves possession of the backed-up key rather than a reflexive
+click.
+
+#### Scenario: Activation blocked until key backup is proven
+- **WHEN** an administrator attempts to enable encrypted writes or start a forward
+  migration and the key backup has not yet been confirmed
+- **THEN** the operation does not proceed and the operator is warned about irreversible
+  data loss on key loss
+
+#### Scenario: Confirmation requires the key fingerprint, not just a checkbox
+- **WHEN** the administrator confirms the key backup
+- **THEN** the confirmation is accepted only if the entered key fingerprint (or recovery
+  code) matches the value derived from the current master key
+- **AND** an incorrect or empty value is rejected and activation remains blocked
+
+#### Scenario: Gate triggers on encrypted writes even without migration
+- **WHEN** an administrator enables encryption so that new documents are written
+  encrypted, without ever starting the forward migration
+- **THEN** the key-backup confirmation is still required before the first encrypted write
+
+### Requirement: Keystore Provisioning via the Client
+
+The system SHALL allow an administrator to provide the master key to a server that is
+missing it by uploading the previously backed-up keystore through the client, so that a
+migrated or rebuilt server can be unlocked without filesystem or shell access. On
+receipt, the server SHALL write the keystore to the configured key location with
+restrictive permissions and SHALL unlock the document subsystem. This is a transport
+mechanism for the existing key only; it does not replace the key-backup obligation and
+introduces no alternative key-derivation scheme.
+
+The upload SHALL be restricted to the `sysAdminRole`, SHALL be audited, and SHALL be
+transmitted only over a transport-encrypted (TLS) channel; the key bytes SHALL NOT be
+logged. Before accepting the key, the server SHALL validate that it matches the existing
+encrypted data (for example via a key fingerprint or a test unwrap) and SHALL reject a
+non-matching key. The server SHALL NOT silently overwrite an existing key; replacing a
+present key SHALL require an explicit replace action.
+
+#### Scenario: Locked server is unlocked by uploading the keystore
+- **WHEN** a server has encryption enabled but no master key, and an administrator
+  uploads the correct backed-up keystore through the client over a TLS-secured channel
+- **THEN** the server stores the keystore at the configured location with restrictive
+  permissions
+- **AND** validates that it matches the encrypted data
+- **AND** unlocks the document subsystem so documents become accessible again
+
+#### Scenario: Non-matching or unauthorized upload is rejected
+- **WHEN** the uploaded keystore does not match the encrypted data, or the caller does
+  not hold `sysAdminRole`, or the channel is not transport-encrypted
+- **THEN** the server rejects the upload and the document subsystem remains locked
+
+#### Scenario: Existing key is not silently overwritten
+- **WHEN** an administrator uploads a keystore while a key already exists at the
+  configured location
+- **THEN** the server does not overwrite it unless an explicit replace action is taken
+
+### Requirement: Keystore Export (Download) via the Client
+
+The system SHALL allow a `sysAdminRole` to download the current keystore through the
+client (and REST), so the administrator can create the off-server backup that the
+key-backup safeguard requires. The download SHALL be offered at the moments new key
+material is created — initial key initialization/activation and key rotation — and SHALL
+also be available on demand thereafter. The export SHALL be restricted to the
+`sysAdminRole`, SHALL be audited, SHALL be transmitted only over a transport-encrypted
+(TLS/HTTPS) channel, and the key bytes SHALL NOT be logged.
+
+Because key rotation re-wraps data keys under the new master key, after a rotation the
+previous key backup no longer suffices; the system SHALL make the new keystore available
+for download and SHALL require its backup to be confirmed (via the key-backup safeguard)
+as part of completing rotation.
+
+#### Scenario: Download the keystore at activation to back it up
+- **WHEN** a `sysAdminRole` initializes/activates encryption
+- **THEN** the freshly generated keystore can be downloaded through the client over a
+  TLS-secured channel
+- **AND** the downloaded keystore is the backup whose possession is later proven at the
+  key-backup gate
+
+#### Scenario: Download the new keystore after rotation
+- **WHEN** a `sysAdminRole` rotates the master key
+- **THEN** the new keystore can be downloaded
+- **AND** rotation requires the new key's backup to be confirmed, since the previous key
+  backup can no longer decrypt the re-wrapped data
+
+#### Scenario: Export is denied without privilege or transport security
+- **WHEN** a keystore download is attempted by a caller without `sysAdminRole`, or over a
+  non-TLS channel
+- **THEN** the request is rejected and no key material is returned
+
+### Requirement: Configurable Enablement and Key Source
+
+The system SHALL expose configuration to enable or disable encryption at rest and to
+select the master-key source. Encryption SHALL be **disabled by default** on both new
+installations and upgrades, so that the system stores and reads documents as plaintext
+until an administrator explicitly opts in.
+
+#### Scenario: Feature disabled by default on upgrade
+- **WHEN** the new version is deployed to an existing installation without configuration
+- **THEN** documents continue to be stored and read as plaintext until encryption is
+  explicitly enabled
+
+#### Scenario: Feature disabled by default on new install
+- **WHEN** a fresh installation is set up without configuring encryption
+- **THEN** documents are stored as plaintext until an administrator enables encryption
+
+#### Scenario: Administrator enables encryption
+- **WHEN** an administrator enables encryption and configures a valid key source
+- **THEN** new writes are encrypted and the migration tooling becomes available
+
+### Requirement: Encryption Administration Restricted to System Administrators
+
+The system SHALL authorize encryption administration operations only for the
+`sysAdminRole` — this covers enable/disable, key initialization, the key-backup
+confirmation, keystore upload, forward migration, reverse migration, and key rotation.
+The ordinary `adminRole` SHALL NOT be permitted to perform these operations. This applies
+identically to the client and REST surfaces.
+
+#### Scenario: System administrator may operate encryption
+- **WHEN** a user holding `sysAdminRole` invokes an encryption administration operation
+- **THEN** the operation is authorized
+
+#### Scenario: Ordinary administrator is denied
+- **WHEN** a user holding only `adminRole` (not `sysAdminRole`) invokes any encryption
+  administration operation, via the client or REST
+- **THEN** the operation is refused as unauthorized
+
+### Requirement: Explicit Key Initialization
+
+The master key SHALL be created only by an explicit, audited administrator action, and
+SHALL NOT be generated automatically by database schema migration or by server startup.
+Key creation SHALL generate a cryptographically random master key, store it (with its
+metadata) outside the data directory, and SHALL refuse to overwrite an existing key.
+
+#### Scenario: Schema migration does not create keys
+- **WHEN** the new version is deployed and database migrations run
+- **THEN** only bookkeeping schema changes are applied
+- **AND** no master key is generated and encryption remains disabled until an
+  administrator initializes it
+
+#### Scenario: Existing key is not overwritten
+- **WHEN** an administrator triggers key initialization while a key already exists
+- **THEN** the operation refuses and the existing key is preserved
+
+### Requirement: Bounded Performance Overhead
+
+Encryption and decryption SHALL add only marginal overhead to per-document operations
+for typical document sizes, and per-key derivation (PBKDF2/KDF) SHALL be performed once
+at startup rather than per file, so that the master key is not re-derived on each
+read/write.
+
+#### Scenario: Key derivation runs once
+- **WHEN** the server processes many document reads and writes after startup
+- **THEN** the key-derivation function is not re-invoked per operation
+
+#### Scenario: Throughput remains acceptable for typical documents
+- **WHEN** authenticated users read and write documents of typical size
+- **THEN** the added latency from encryption is marginal relative to existing I/O
+
+### Requirement: REST Administration of Encryption
+
+The system SHALL expose the encryption administration operations — enable/disable,
+key-backup confirmation, keystore upload, forward migration, reverse migration, and key
+rotation, plus status/progress retrieval — through the REST API so that a server-only or
+headless installation can be administered without the desktop client. These endpoints
+SHALL be backed by the same server operations as the client and SHALL be added in the
+latest API version without changing existing versions.
+
+The REST endpoints SHALL require the `sysAdminRole`, SHALL be served only over a
+transport-encrypted (HTTPS) channel for any operation that carries key material
+(notably keystore upload), SHALL NOT log key material, and long-running operations SHALL
+start asynchronously and report progress via a status endpoint (consistent with the
+existing administration job-status pattern).
+
+#### Scenario: Headless server is administered via REST
+- **WHEN** an administrator calls the REST encryption endpoints on a server with no
+  desktop client
+- **THEN** the administrator can enable encryption, upload the keystore, and start
+  migration or rotation
+- **AND** can poll operation status until completion
+
+#### Scenario: REST keystore upload requires HTTPS and admin role
+- **WHEN** a keystore upload is attempted over a non-HTTPS channel or without
+  `sysAdminRole`
+- **THEN** the request is rejected and no key material is accepted
+
+### Requirement: Audit Logging of Bulk Cryptographic Operations
+
+The system SHALL record an audit entry for the start and completion of forward
+migration, reverse migration, and key rotation, including who initiated the operation
+and its outcome.
+
+#### Scenario: Migration is auditable
+- **WHEN** an administrator runs a migration or key rotation
+- **THEN** an audit record captures the initiator, operation type, and result

--- a/openspec/changes/add-document-encryption-at-rest/tasks.md
+++ b/openspec/changes/add-document-encryption-at-rest/tasks.md
@@ -1,0 +1,103 @@
+## 0. Decisions
+- [x] 0.1 Master-key source: key file on server, auto-unlock at startup (C1)
+- [x] 0.2 Single firm-wide key domain + per-file envelope keys (C3)
+- [x] 0.3 Scope: only archivefiles/ + archivefiles-preview/; Lucene index plaintext = accepted residual risk (C2)
+- [x] 0.4 Migration: admin-triggered resumable online batch + reverse + rotation (C4)
+- [x] 0.5a DataBucket path supported via server-side streaming decrypt to temp (C5/Q8)
+- [x] 0.5b Data directory 20–150 GB → I/O-bound, online/resumable/throttled migration (Q9)
+- [x] 0.5c ~5% steady-state overhead acceptable; AES-NI may be assumed (Q9, Q10)
+- [x] 0.6a Default OFF on new installs and upgrades (Q11); compliance: DSGVO + BRAO/StGB (Q13)
+- [x] 0.6b Scope is by storage path: dictation/audio + saved e-mails are documents under archivefiles/, auto-covered; no separate store (Q5)
+- [x] 0.6c Key-backup gate at activation; Variant B (typed fingerprint/recovery code) (Q3)
+- [x] 0.6 Option A scoped fail-closed + startup health check on invalid key (Q12)
+- [ ] 0.6 Confirm default-on-vs-off, key-backup UX, compliance drivers (Q3, Q11, Q13)
+
+## 1. Crypto primitive (j-lawyer-server-common)
+- [ ] 1.1 Add `FileCrypto` AES-256-GCM utility: random per-file IV, 128-bit tag,
+      encrypt/decrypt over byte[] (and streaming variant if 1.4 required)
+- [ ] 1.2 Define self-describing file header (magic, version, algoId, wrapped DEK, IV)
+- [ ] 1.3 Implement header detection (isEncrypted) for mixed-state reads
+- [ ] 1.4 Streaming GCM decrypt/encrypt (required for the DataBucket path, C5)
+- [ ] 1.5 Unit tests: round-trip, tamper detection, wrong key, header detection,
+      plaintext passthrough
+
+## 2. Key management
+- [ ] 2.1 Implement master-key (KEK) provider: key file / PKCS12 keystore outside
+      basedirectory, chmod 600; optional keystore password via system property/env var
+- [ ] 2.2 Per-install random salt + key metadata stored alongside the key (NOT in DB);
+      KDF run once at startup, key cached in memory
+- [ ] 2.3 Envelope: generate/wrap/unwrap per-file data keys; crypto material in file header
+- [ ] 2.4 Key rotation: re-wrap data keys under a new master key (bump key version)
+- [ ] 2.5 Scoped fail-closed on missing/invalid key (document subsystem only; app keeps
+      running) + startup health check that disables document functions and warns loudly
+- [ ] 2.6 Explicit "Initialize encryption" action (`sysAdminRole`): SecureRandom KEK, write
+      key + metadata, refuse overwrite, gate on backup confirmation (NOT a Flyway/startup step)
+- [ ] 2.7 Tests for wrap/unwrap, rotation, fail-closed, init-refuses-overwrite
+- [ ] 2.8 Document that key location is excluded from document backups
+
+## 3. Document storage integration (j-lawyer-server-ejb)
+- [ ] 3.0a Flyway SQL migration `V<x>__AddDocumentEncryptionColumns.sql`: add
+      `encryption_state` + `key_version` to `case_documents` (schema only, inert when off)
+- [ ] 3.0b Add the two bookkeeping fields to `ArchiveFileDocumentsBean` (hints, header is
+      authoritative); keep `size` = logical plaintext length
+- [ ] 3.1 Introduce a document-storage layer scoped to `archivefiles/` and
+      `archivefiles-preview/` (do NOT encrypt all `ServerFileUtils` callers)
+- [ ] 3.2 Wire encryption into `ArchiveFileService` write paths
+      (`addDocumentImpl`, `setDocumentContent`)
+- [ ] 3.3 Wire decryption into read paths (`getDocumentContentImpl`, unrestricted reads)
+- [ ] 3.3a `getDocumentContentBucket`: replace `Files.copy(src→temp)` with streaming
+      decrypt into the temp bucket file; ensure temp file cleanup (C5)
+- [ ] 3.4 Wire `PreviewGenerator` text/PDF preview read+write
+- [ ] 3.5 Verify search indexing receives decrypted text; confirm whether the
+      Lucene index is in/out of scope per 0.3
+
+## 4. Configuration & admin surface
+- [ ] 4.1 Server config in `server_settings` (via ServerSettingsKeys): enable flag
+      (`jlawyer.server.encryption.enabled`, default off) + key-source/path selection
+- [ ] 4.2 EJB operations: start/stop/status for forward migration, reverse migration,
+      key rotation — `@RolesAllowed({"sysAdminRole"})` (NOT adminRole); run server-side as
+      background jobs that survive client disconnect and report progress/status
+- [ ] 4.3 Key-backup gate at ACTIVATION (before encrypted writes OR migration, whichever
+      first); Variant B: require typed key fingerprint/recovery code matching the key
+- [ ] 4.4 Client admin dialog under `AdminConsoleFrame` (+ `.form`) for enablement,
+      migration, rollback, rotation, key-backup gate and keystore upload — following the
+      `SearchIndexOptionsDialog` "reindex" pattern (trigger + status, work runs on server)
+- [ ] 4.5 Audit logging for migration/rotation start+completion
+- [ ] 4.6 Keystore upload: client upload dialog (+ `.form`) + `sysAdminRole` EJB op that
+      writes the keystore to the configured path (chmod 600), validates key-matches-data before
+      accepting, refuses silent overwrite, requires TLS channel, never logs key bytes,
+      audited (C6)
+- [ ] 4.6a Keystore download/export: client download (+ `.form`) + `sysAdminRole` EJB op;
+      offered at activation and rotation and on demand; TLS, audited, never logs key bytes;
+      rotation requires new-key backup confirmation before completing (C6)
+- [ ] 4.7 Expose locked-state ("encryption enabled, key missing") to the client so the
+      upload flow can be offered
+- [ ] 4.8 REST API (v8): encryption admin endpoints (enable/disable, key-backup confirm,
+      keystore upload + download, forward/reverse migration, rotation, status) backed by
+      the same EJB ops; `sysAdminRole` only, HTTPS required for key material, async + status
+      modelled on `AdministrationEndpointV7` (`/jobs/{id}/status`); key bytes never logged
+- [ ] 4.9 Regenerate + re-baseline `swagger.json` (`mvn -Pswagger-regen`), keep
+      `SwaggerEquivalenceTest` green
+
+## 5. Migration tooling (sized for 20–150 GB, I/O-bound)
+- [ ] 5.1 Idempotent, resumable forward migration over both folders with progress + ETA
+- [ ] 5.2 Reverse migration (decrypt-all) with progress
+- [ ] 5.3 Online-safe behaviour (handle concurrent reads/writes during migration)
+- [ ] 5.4 Crash-safe in-place rewrite: temp file in same dir → fsync → atomic rename
+- [ ] 5.5 Throttling control to bound migration I/O (off-hours / rate limit)
+- [ ] 5.6 Migration tests on a mixed-state directory (incl. interrupt/resume + crash mid-file)
+
+## 6. Operational / docs
+- [ ] 6.1 Document key backup/restore, server migration via client keystore upload (C6),
+      and interaction with `j-lawyer-backupmgr`
+- [ ] 6.1a Document per-OS keystore locations (Linux/Windows/macOS/Docker), perms/ACL, and
+      Docker: dedicated volume/secret outside the (777) data volume
+- [ ] 6.2 Document residual risks (Lucene index, DB, templates) per 0.3
+- [ ] 6.3 Document CPU/AES-NI expectations and migration runtime guidance
+- [ ] 6.4 Verify Nextcloud/cloud sync reads via `getDocumentContent` (decrypted), not
+      raw disk; document that the shared copy is plaintext (Q14)
+
+## 7. Validation
+- [ ] 7.1 `openspec validate add-document-encryption-at-rest --strict`
+- [ ] 7.2 End-to-end: enable → write → read → search → preview → migrate → rotate →
+      reverse-migrate on a test data directory


### PR DESCRIPTION
OpenSpec proposal for **encryption at rest** of case documents in the `archivefiles/` and `archivefiles-preview/` folders. New capability `document-encryption`.

Proposal only — implementation follows later in a separate branch.

## Key decisions (see `design.md`)
- AES-256-GCM, per-file random IV, envelope keys; crypto material in a self-describing file header (DB carries only bookkeeping hints).
- Master key in a keystore file on the server, outside `basedirectory`, excluded from backups; auto-unlock at startup.
- Scope: `archivefiles/` + `archivefiles-preview/` only (Lucene index left plaintext = accepted residual risk).
- Admin-triggered, resumable, online migration (forward/reverse) + key rotation; ~5% overhead, sized for 20–150 GB.
- Scoped fail-closed + startup health check on missing/invalid key.
- Key-backup gate at activation (typed key fingerprint, not a checkbox).
- Keystore upload/download via client and REST (v8); all encryption admin ops restricted to `sysAdminRole`.
- Disabled by default on new installs and upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)