### PR TITLE
Normalize unusable LibreOffice UNO document windows (#3483)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/WaitForDocumentAction.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/WaitForDocumentAction.java
@@ -704,6 +704,7 @@ public class WaitForDocumentAction extends ProgressableAction {
 
     private boolean isOpenForWrite(String docId) {
         DocumentObserver observer = DocumentObserver.getInstance();
+        observer.observe();
         if (observer.isDocumentOpen(docId)) {
             return !(observer.isDocumentReadOnly(docId));
         }
@@ -726,6 +727,10 @@ public class WaitForDocumentAction extends ProgressableAction {
             open = this.isOpenForWrite(doc.getId());
             if (open) {
                 ObservedDocument odoc = DocumentObserver.getInstance().getDocumentById(doc.getId());
+                if (odoc == null) {
+                    this.proceed = true;
+                    return true;
+                }
                 if (odoc.getStatus() != ObservedDocument.STATUS_CLOSING) {
                     Thread.sleep(500);
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/DocumentObserver.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/DocumentObserver.java
@@ -809,6 +809,9 @@ public class DocumentObserver {
             }
 
             if (closed) {
+                if (doc instanceof ObservedOfficeDocument) {
+                    ((ObservedOfficeDocument) doc).closeUnoMonitorSession();
+                }
                 for (DocumentObserverListener l : listeners) {
                     if (l != null) {
                         l.documentClosed(doc);

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
@@ -9,9 +9,6 @@
  */
 package com.jdimension.jlawyer.client.launcher;
 
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.Rectangle;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Array;
@@ -42,10 +39,6 @@ public class JavaUnoOfficeMonitor {
     private static final String PROP_UNO_EXTRA_ARGS = "jlawyer.uno.extraArgs";
     private static final String PROP_UNO_PORT = "jlawyer.uno.port";
     private static final String ENV_UNO_CLASSPATH = "JLAWYER_UNO_CLASSPATH";
-    private static final int MIN_WINDOW_WIDTH = 800;
-    private static final int MIN_WINDOW_HEIGHT = 600;
-    private static final int DEFAULT_WINDOW_WIDTH = 1200;
-    private static final int DEFAULT_WINDOW_HEIGHT = 900;
 
     private JavaUnoOfficeMonitor() {
     }
@@ -88,7 +81,6 @@ public class JavaUnoOfficeMonitor {
             }
             componentLoaded = true;
 
-            normalizeDocumentWindow(uno, component);
             List<Object> listeners = registerListeners(uno, component, document);
             document.setUnoMonitorSession(new MonitorSession(unoClassLoader, process, resolver, remoteContext, component, listeners));
             document.setUnoMonitoringActive(true);
@@ -133,120 +125,6 @@ public class JavaUnoOfficeMonitor {
             listeners.add(modifyListener);
         }
         return listeners;
-    }
-
-    private static void normalizeDocumentWindow(UnoClasses uno, Object component) {
-        for (int attempt = 0; attempt < 5; attempt++) {
-            normalizeDocumentWindowOnce(uno, component);
-            if (attempt < 4) {
-                try {
-                    Thread.sleep(150);
-                } catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                    return;
-                }
-            }
-        }
-    }
-
-    private static void normalizeDocumentWindowOnce(UnoClasses uno, Object component) {
-        try {
-            Object model = queryInterface(uno, uno.xModel, component);
-            if (model == null) {
-                return;
-            }
-            Object controller = invoke(model, "getCurrentController");
-            if (controller == null) {
-                return;
-            }
-            Object frame = invoke(controller, "getFrame");
-            if (frame == null) {
-                return;
-            }
-            Object xFrame = queryInterface(uno, uno.xFrame, frame);
-            if (xFrame == null) {
-                return;
-            }
-            Object containerWindow = queryInterface(uno, uno.xWindow, invoke(xFrame, "getContainerWindow"));
-            if (containerWindow == null) {
-                return;
-            }
-
-            invoke(containerWindow, "setVisible", Boolean.TRUE);
-            Rectangle currentBounds = getUnoWindowBounds(containerWindow);
-            if (!isWindowUsable(currentBounds)) {
-                Rectangle safeBounds = getSafeWindowBounds();
-                invoke(containerWindow, "setPosSize",
-                        Integer.valueOf(safeBounds.x),
-                        Integer.valueOf(safeBounds.y),
-                        Integer.valueOf(safeBounds.width),
-                        Integer.valueOf(safeBounds.height),
-                        getPosSizeAllFlag(uno));
-                log.debug("Normalized LibreOffice document window from " + currentBounds + " to " + safeBounds);
-            }
-            invoke(containerWindow, "setFocus");
-        } catch (Throwable t) {
-            log.debug("Could not normalize LibreOffice document window: " + t.getMessage(), t);
-        }
-    }
-
-    private static Rectangle getUnoWindowBounds(Object window) throws Exception {
-        Object bounds = invoke(window, "getPosSize");
-        return new Rectangle(
-                getIntField(bounds, "X"),
-                getIntField(bounds, "Y"),
-                getIntField(bounds, "Width"),
-                getIntField(bounds, "Height"));
-    }
-
-    private static int getIntField(Object object, String name) throws Exception {
-        Field field = object.getClass().getField(name);
-        return ((Number) field.get(object)).intValue();
-    }
-
-    private static Object getPosSizeAllFlag(UnoClasses uno) throws Exception {
-        Field field = uno.posSize.getField("POSSIZE");
-        return Short.valueOf(((Number) field.get(null)).shortValue());
-    }
-
-    private static boolean isWindowUsable(Rectangle bounds) {
-        if (bounds == null || bounds.width < MIN_WINDOW_WIDTH || bounds.height < MIN_WINDOW_HEIGHT) {
-            return false;
-        }
-
-        Rectangle screenBounds = getVirtualScreenBounds();
-        if (screenBounds == null) {
-            return true;
-        }
-        Rectangle visibleBounds = screenBounds.intersection(bounds);
-        return visibleBounds.width >= MIN_WINDOW_WIDTH / 2 && visibleBounds.height >= MIN_WINDOW_HEIGHT / 2;
-    }
-
-    private static Rectangle getSafeWindowBounds() {
-        Rectangle screenBounds = getVirtualScreenBounds();
-        if (screenBounds == null) {
-            return new Rectangle(100, 100, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
-        }
-
-        int width = Math.min(DEFAULT_WINDOW_WIDTH, Math.max(MIN_WINDOW_WIDTH, screenBounds.width - 100));
-        int height = Math.min(DEFAULT_WINDOW_HEIGHT, Math.max(MIN_WINDOW_HEIGHT, screenBounds.height - 100));
-        int x = screenBounds.x + Math.max(50, (screenBounds.width - width) / 2);
-        int y = screenBounds.y + Math.max(50, (screenBounds.height - height) / 2);
-        return new Rectangle(x, y, width, height);
-    }
-
-    private static Rectangle getVirtualScreenBounds() {
-        try {
-            GraphicsEnvironment environment = GraphicsEnvironment.getLocalGraphicsEnvironment();
-            Rectangle bounds = null;
-            for (GraphicsDevice device : environment.getScreenDevices()) {
-                Rectangle deviceBounds = device.getDefaultConfiguration().getBounds();
-                bounds = bounds == null ? new Rectangle(deviceBounds) : bounds.union(deviceBounds);
-            }
-            return bounds;
-        } catch (Throwable t) {
-            return null;
-        }
     }
 
     private static Object connect(UnoClasses uno, Object resolver, int port, Process process) throws Exception {
@@ -500,10 +378,6 @@ public class JavaUnoOfficeMonitor {
         private final Class<?> xCloseListener;
         private final Class<?> xModifyBroadcaster;
         private final Class<?> xModifyListener;
-        private final Class<?> xModel;
-        private final Class<?> xFrame;
-        private final Class<?> xWindow;
-        private final Class<?> posSize;
 
         UnoClasses(ClassLoader loader) throws Exception {
             this.loader = loader;
@@ -519,10 +393,6 @@ public class JavaUnoOfficeMonitor {
             this.xCloseListener = Class.forName("com.sun.star.util.XCloseListener", true, loader);
             this.xModifyBroadcaster = Class.forName("com.sun.star.util.XModifyBroadcaster", true, loader);
             this.xModifyListener = Class.forName("com.sun.star.util.XModifyListener", true, loader);
-            this.xModel = Class.forName("com.sun.star.frame.XModel", true, loader);
-            this.xFrame = Class.forName("com.sun.star.frame.XFrame", true, loader);
-            this.xWindow = Class.forName("com.sun.star.awt.XWindow", true, loader);
-            this.posSize = Class.forName("com.sun.star.awt.PosSize", true, loader);
         }
     }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
@@ -1,0 +1,463 @@
+/*
+ *                     GNU AFFERO GENERAL PUBLIC LICENSE
+ *                        Version 3, 19 November 2007
+ *
+ *  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ *  Everyone is permitted to copy and distribute verbatim copies
+ *  of this license document, but changing it is not allowed.
+ *
+ */
+package com.jdimension.jlawyer.client.launcher;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.log4j.Logger;
+
+/**
+ * Optional LibreOffice UNO launcher/monitor.
+ *
+ * This class deliberately avoids compile-time UNO imports. Java UNO support is
+ * not present in every LibreOffice installation, so all UNO classes are loaded
+ * reflectively and callers can fall back to lock-file monitoring on any error.
+ */
+public class JavaUnoOfficeMonitor {
+
+    private static final Logger log = Logger.getLogger(JavaUnoOfficeMonitor.class.getName());
+    private static final String PROP_UNO_CLASSPATH = "jlawyer.uno.classpath";
+    private static final String PROP_UNO_EXTRA_ARGS = "jlawyer.uno.extraArgs";
+    private static final String PROP_UNO_PORT = "jlawyer.uno.port";
+    private static final String ENV_UNO_CLASSPATH = "JLAWYER_UNO_CLASSPATH";
+
+    private JavaUnoOfficeMonitor() {
+    }
+
+    public static boolean launch(String officeBinary, String documentPath, ObservedOfficeDocument document) {
+        URLClassLoader unoClassLoader = null;
+        Process process = null;
+        boolean componentLoaded = false;
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            List<URL> unoJars = findUnoJars(officeBinary);
+            if (unoJars.isEmpty()) {
+                log.debug("Java UNO jars not found - falling back to lock-file monitoring");
+                return false;
+            }
+
+            unoClassLoader = new URLClassLoader(unoJars.toArray(new URL[unoJars.size()]), JavaUnoOfficeMonitor.class.getClassLoader());
+            Thread.currentThread().setContextClassLoader(unoClassLoader);
+            UnoClasses uno = new UnoClasses(unoClassLoader);
+
+            int port = findFreePort();
+            process = startOfficeProcess(officeBinary, port);
+            drain(process.getInputStream());
+
+            Object localContext = uno.bootstrap.getMethod("createInitialComponentContext", java.util.Hashtable.class).invoke(null, new Object[]{null});
+            Object localServiceManager = invoke(localContext, "getServiceManager");
+            Object resolverObject = invoke(localServiceManager, "createInstanceWithContext", "com.sun.star.bridge.UnoUrlResolver", localContext);
+            Object resolver = queryInterface(uno, uno.xUnoUrlResolver, resolverObject);
+            Object remoteContext = connect(uno, resolver, port, process);
+
+            Object remoteServiceManager = invoke(remoteContext, "getServiceManager");
+            Object desktopObject = invoke(remoteServiceManager, "createInstanceWithContext", "com.sun.star.frame.Desktop", remoteContext);
+            Object loader = queryInterface(uno, uno.xComponentLoader, desktopObject);
+            Object propertyValues = Array.newInstance(uno.propertyValue, 0);
+            Object component = invoke(loader, "loadComponentFromURL", toFileUrl(documentPath), "_blank", Integer.valueOf(0), propertyValues);
+            if (component == null) {
+                destroyQuietly(process);
+                log.debug("UNO returned no document component - falling back to lock-file monitoring");
+                return false;
+            }
+            componentLoaded = true;
+
+            List<Object> listeners = registerListeners(uno, component, document);
+            document.setUnoMonitorSession(new MonitorSession(unoClassLoader, process, resolver, remoteContext, component, listeners));
+            document.setUnoMonitoringActive(true);
+            log.debug("UNO monitoring active for " + documentPath);
+            return true;
+
+        } catch (Throwable t) {
+            if (componentLoaded) {
+                log.warn("UNO opened document but monitoring is unavailable. Continuing with lock-file monitoring: " + t.getMessage(), t);
+                return true;
+            } else {
+                destroyQuietly(process);
+                log.debug("UNO monitoring unavailable - falling back to lock-file monitoring: " + t.getMessage(), t);
+                return false;
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static List<Object> registerListeners(UnoClasses uno, Object component, ObservedOfficeDocument document) throws Exception {
+        List<Object> listeners = new ArrayList<>();
+
+        Object eventBroadcaster = queryInterface(uno, uno.xEventBroadcaster, component);
+        if (eventBroadcaster != null) {
+            Object eventListener = Proxy.newProxyInstance(uno.loader, new Class[]{uno.xDocumentEventListener}, new DocumentEventHandler(document));
+            invoke(eventBroadcaster, "addEventListener", eventListener);
+            listeners.add(eventListener);
+        }
+
+        Object closeBroadcaster = queryInterface(uno, uno.xCloseBroadcaster, component);
+        if (closeBroadcaster != null) {
+            Object closeListener = Proxy.newProxyInstance(uno.loader, new Class[]{uno.xCloseListener}, new CloseEventHandler(document));
+            invoke(closeBroadcaster, "addCloseListener", closeListener);
+            listeners.add(closeListener);
+        }
+
+        Object modifyBroadcaster = queryInterface(uno, uno.xModifyBroadcaster, component);
+        if (modifyBroadcaster != null) {
+            Object modifyListener = Proxy.newProxyInstance(uno.loader, new Class[]{uno.xModifyListener}, new ModifyEventHandler(document));
+            invoke(modifyBroadcaster, "addModifyListener", modifyListener);
+            listeners.add(modifyListener);
+        }
+        return listeners;
+    }
+
+    private static Object connect(UnoClasses uno, Object resolver, int port, Process process) throws Exception {
+        Method resolve = uno.xUnoUrlResolver.getMethod("resolve", String.class);
+        Throwable lastError = null;
+        for (int i = 0; i < 50; i++) {
+            try {
+                Object remoteContext = resolve.invoke(resolver, "uno:socket,host=localhost,port=" + port + ";urp;StarOffice.ComponentContext");
+                return queryInterface(uno, uno.xComponentContext, remoteContext);
+            } catch (Throwable t) {
+                lastError = t;
+                if (i >= 5 && process != null && !process.isAlive()) {
+                    throw new IllegalStateException("LibreOffice process exited before UNO accepted connections", lastError);
+                }
+                Thread.sleep(100);
+            }
+        }
+        throw new IllegalStateException("Could not connect to LibreOffice UNO", lastError);
+    }
+
+    private static Process startOfficeProcess(String officeBinary, int port) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add(officeBinary);
+        command.add("--norestore");
+        command.add("--nofirststartwizard");
+        command.add("--accept=socket,host=localhost,port=" + port + ";urp;");
+        for (String extraArg : getExtraArgs()) {
+            command.add(extraArg);
+        }
+        return new ProcessBuilder(command).redirectErrorStream(true).start();
+    }
+
+    private static List<String> getExtraArgs() {
+        List<String> args = new ArrayList<>();
+        String configured = System.getProperty(PROP_UNO_EXTRA_ARGS, "");
+        if (configured.trim().isEmpty()) {
+            return args;
+        }
+        for (String part : configured.split(",")) {
+            String arg = part.trim();
+            if (!arg.isEmpty()) {
+                args.add(arg);
+            }
+        }
+        return args;
+    }
+
+    private static List<URL> findUnoJars(String officeBinary) throws Exception {
+        Set<File> files = new LinkedHashSet<>();
+        addConfiguredClasspath(files, System.getProperty(PROP_UNO_CLASSPATH));
+        addConfiguredClasspath(files, System.getenv(ENV_UNO_CLASSPATH));
+
+        File binary = new File(officeBinary);
+        if (binary.isAbsolute()) {
+            File parent = binary.getParentFile();
+            if (parent != null) {
+                addJarDirectory(files, parent);
+                addJarDirectory(files, new File(parent, "classes"));
+                File appRoot = parent.getParentFile();
+                if (appRoot != null) {
+                    addJarDirectory(files, new File(appRoot, "Resources/java"));
+                }
+            }
+        }
+
+        addJarDirectory(files, new File("/usr/lib/libreoffice/program/classes"));
+        addJarDirectory(files, new File("/usr/lib/libreoffice/program"));
+        addJarDirectory(files, new File("/usr/share/java"));
+        addJarDirectory(files, new File("/Applications/LibreOffice.app/Contents/Resources/java"));
+        addJarDirectory(files, new File("C:\\Program Files\\LibreOffice\\program\\classes"));
+        addJarDirectory(files, new File("C:\\Program Files (x86)\\LibreOffice\\program\\classes"));
+
+        List<URL> urls = new ArrayList<>();
+        for (File file : files) {
+            if (file.isFile()) {
+                urls.add(file.toURI().toURL());
+            }
+        }
+        return urls;
+    }
+
+    private static void addConfiguredClasspath(Set<File> files, String classpath) {
+        if (classpath == null || classpath.trim().isEmpty()) {
+            return;
+        }
+        for (String part : classpath.split(File.pathSeparator)) {
+            File file = new File(part.trim());
+            if (file.isDirectory()) {
+                addJarDirectory(files, file);
+            } else if (file.isFile() && file.getName().toLowerCase().endsWith(".jar")) {
+                files.add(file);
+            }
+        }
+    }
+
+    private static void addJarDirectory(Set<File> files, File directory) {
+        if (directory == null || !directory.isDirectory()) {
+            return;
+        }
+        File[] jarFiles = directory.listFiles((File file) -> file.isFile() && isUnoJar(file));
+        if (jarFiles == null) {
+            return;
+        }
+        for (File jarFile : jarFiles) {
+            files.add(jarFile);
+        }
+    }
+
+    private static boolean isUnoJar(File file) {
+        String name = file.getName().toLowerCase();
+        return name.equals("juh.jar")
+                || name.equals("jurt.jar")
+                || name.equals("ridl.jar")
+                || name.equals("unoil.jar")
+                || name.equals("unoloader.jar")
+                || name.equals("libreoffice.jar")
+                || name.equals("officebean.jar")
+                || name.startsWith("unoil-")
+                || name.startsWith("libreoffice-");
+    }
+
+    private static Object queryInterface(UnoClasses uno, Class<?> iface, Object object) throws Exception {
+        return uno.unoRuntime.getMethod("queryInterface", Class.class, Object.class).invoke(null, iface, object);
+    }
+
+    private static Object invoke(Object target, String methodName, Object... args) throws Exception {
+        Method method = findMethod(target.getClass(), methodName, args);
+        return method.invoke(target, args);
+    }
+
+    private static Method findMethod(Class<?> type, String methodName, Object[] args) {
+        for (Method method : type.getMethods()) {
+            if (!method.getName().equals(methodName) || method.getParameterTypes().length != args.length) {
+                continue;
+            }
+            return method;
+        }
+        throw new IllegalArgumentException("Method not found: " + methodName);
+    }
+
+    private static String toFileUrl(String path) {
+        return new File(path).toURI().toString();
+    }
+
+    private static int findFreePort() throws Exception {
+        String configuredPort = System.getProperty(PROP_UNO_PORT, "").trim();
+        if (!configuredPort.isEmpty()) {
+            return Integer.parseInt(configuredPort);
+        }
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static void drain(final InputStream stream) {
+        Thread drainThread = new Thread(() -> {
+            byte[] buffer = new byte[1024];
+            try {
+                while (stream.read(buffer) >= 0) {
+                    // drain process output
+                }
+            } catch (Throwable t) {
+                // ignore process output drain failures
+            }
+        }, "j-lawyer-uno-output-drain");
+        drainThread.setDaemon(true);
+        drainThread.start();
+    }
+
+    private static void destroyQuietly(Process process) {
+        if (process != null) {
+            try {
+                process.destroy();
+            } catch (Throwable t) {
+                // ignore cleanup failures
+            }
+        }
+    }
+
+    public static class MonitorSession {
+
+        private final URLClassLoader classLoader;
+        private final Process process;
+        private final Object resolver;
+        private final Object remoteContext;
+        private final Object component;
+        private final List<Object> listeners;
+
+        MonitorSession(URLClassLoader classLoader, Process process, Object resolver, Object remoteContext, Object component, List<Object> listeners) {
+            this.classLoader = classLoader;
+            this.process = process;
+            this.resolver = resolver;
+            this.remoteContext = remoteContext;
+            this.component = component;
+            this.listeners = listeners;
+        }
+
+        public void release() {
+            try {
+                classLoader.close();
+            } catch (Throwable t) {
+                log.debug("Could not release UNO classloader: " + t.getMessage(), t);
+            }
+        }
+
+        public void abort() {
+            destroyQuietly(process);
+            release();
+        }
+    }
+
+    private static String getDocumentEventName(Object event) {
+        try {
+            Field eventName = event.getClass().getField("EventName");
+            Object value = eventName.get(event);
+            return value == null ? "" : value.toString();
+        } catch (Throwable t) {
+            return "";
+        }
+    }
+
+    private static boolean isCloseEventName(String eventName) {
+        return "OnUnload".equals(eventName) || "OnClose".equals(eventName);
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] args) {
+        if ("hashCode".equals(method.getName()) && method.getParameterTypes().length == 0) {
+            return Integer.valueOf(System.identityHashCode(proxy));
+        }
+        if ("equals".equals(method.getName()) && args != null && args.length == 1) {
+            return Boolean.valueOf(proxy == args[0]);
+        }
+        if ("toString".equals(method.getName()) && method.getParameterTypes().length == 0) {
+            return proxy.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxy));
+        }
+        return null;
+    }
+
+    private static class UnoClasses {
+
+        private final ClassLoader loader;
+        private final Class<?> bootstrap;
+        private final Class<?> unoRuntime;
+        private final Class<?> propertyValue;
+        private final Class<?> xUnoUrlResolver;
+        private final Class<?> xComponentContext;
+        private final Class<?> xComponentLoader;
+        private final Class<?> xEventBroadcaster;
+        private final Class<?> xDocumentEventListener;
+        private final Class<?> xCloseBroadcaster;
+        private final Class<?> xCloseListener;
+        private final Class<?> xModifyBroadcaster;
+        private final Class<?> xModifyListener;
+
+        UnoClasses(ClassLoader loader) throws Exception {
+            this.loader = loader;
+            this.bootstrap = Class.forName("com.sun.star.comp.helper.Bootstrap", true, loader);
+            this.unoRuntime = Class.forName("com.sun.star.uno.UnoRuntime", true, loader);
+            this.propertyValue = Class.forName("com.sun.star.beans.PropertyValue", true, loader);
+            this.xUnoUrlResolver = Class.forName("com.sun.star.bridge.XUnoUrlResolver", true, loader);
+            this.xComponentContext = Class.forName("com.sun.star.uno.XComponentContext", true, loader);
+            this.xComponentLoader = Class.forName("com.sun.star.frame.XComponentLoader", true, loader);
+            this.xEventBroadcaster = Class.forName("com.sun.star.document.XEventBroadcaster", true, loader);
+            this.xDocumentEventListener = Class.forName("com.sun.star.document.XEventListener", true, loader);
+            this.xCloseBroadcaster = Class.forName("com.sun.star.util.XCloseBroadcaster", true, loader);
+            this.xCloseListener = Class.forName("com.sun.star.util.XCloseListener", true, loader);
+            this.xModifyBroadcaster = Class.forName("com.sun.star.util.XModifyBroadcaster", true, loader);
+            this.xModifyListener = Class.forName("com.sun.star.util.XModifyListener", true, loader);
+        }
+    }
+
+    private static class DocumentEventHandler implements InvocationHandler {
+
+        private final ObservedOfficeDocument document;
+
+        DocumentEventHandler(ObservedOfficeDocument document) {
+            this.document = document;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if (method.getDeclaringClass() == Object.class) {
+                return handleObjectMethod(proxy, method, args);
+            }
+            if ("notifyEvent".equals(method.getName()) && args != null && args.length > 0) {
+                String eventName = getDocumentEventName(args[0]);
+                log.debug("UNO document event " + eventName + " for " + document.getName());
+                if (isCloseEventName(eventName)) {
+                    document.markUnoCloseConfirmed();
+                }
+            }
+            return null;
+        }
+    }
+
+    private static class CloseEventHandler implements InvocationHandler {
+
+        private final ObservedOfficeDocument document;
+
+        CloseEventHandler(ObservedOfficeDocument document) {
+            this.document = document;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if (method.getDeclaringClass() == Object.class) {
+                return handleObjectMethod(proxy, method, args);
+            }
+            if ("notifyClosing".equals(method.getName())) {
+                log.debug("UNO close confirmed for " + document.getName());
+                document.markUnoCloseConfirmed();
+            }
+            return null;
+        }
+    }
+
+    private static class ModifyEventHandler implements InvocationHandler {
+
+        private final ObservedOfficeDocument document;
+
+        ModifyEventHandler(ObservedOfficeDocument document) {
+            this.document = document;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if (method.getDeclaringClass() == Object.class) {
+                return handleObjectMethod(proxy, method, args);
+            }
+            if ("modified".equals(method.getName())) {
+                log.debug("UNO modify event for " + document.getName());
+            }
+            return null;
+        }
+    }
+}

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
@@ -9,6 +9,9 @@
  */
 package com.jdimension.jlawyer.client.launcher;
 
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Array;
@@ -39,6 +42,10 @@ public class JavaUnoOfficeMonitor {
     private static final String PROP_UNO_EXTRA_ARGS = "jlawyer.uno.extraArgs";
     private static final String PROP_UNO_PORT = "jlawyer.uno.port";
     private static final String ENV_UNO_CLASSPATH = "JLAWYER_UNO_CLASSPATH";
+    private static final int MIN_WINDOW_WIDTH = 800;
+    private static final int MIN_WINDOW_HEIGHT = 600;
+    private static final int DEFAULT_WINDOW_WIDTH = 1200;
+    private static final int DEFAULT_WINDOW_HEIGHT = 900;
 
     private JavaUnoOfficeMonitor() {
     }
@@ -81,6 +88,7 @@ public class JavaUnoOfficeMonitor {
             }
             componentLoaded = true;
 
+            normalizeDocumentWindow(uno, component);
             List<Object> listeners = registerListeners(uno, component, document);
             document.setUnoMonitorSession(new MonitorSession(unoClassLoader, process, resolver, remoteContext, component, listeners));
             document.setUnoMonitoringActive(true);
@@ -125,6 +133,129 @@ public class JavaUnoOfficeMonitor {
             listeners.add(modifyListener);
         }
         return listeners;
+    }
+
+    /**
+     * Temporary workaround for a LibreOffice defect: LibreOffice can persist a corrupted
+     * "restored" window geometry (ooSetupFactoryWindowAttributes) after a maximized window
+     * is closed, leaving a freshly opened document window tiny (a barely-visible sliver) or
+     * positioned off-screen (see issue #3483). The root cause lives in LibreOffice; this
+     * mitigation should be removable once that is fixed upstream. The bad geometry is
+     * restored asynchronously, so this retries a few times and only forces usable bounds
+     * when the window is actually unusable.
+     */
+    private static void normalizeDocumentWindow(UnoClasses uno, Object component) {
+        for (int attempt = 0; attempt < 5; attempt++) {
+            normalizeDocumentWindowOnce(uno, component);
+            if (attempt < 4) {
+                try {
+                    Thread.sleep(150);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private static void normalizeDocumentWindowOnce(UnoClasses uno, Object component) {
+        try {
+            Object model = queryInterface(uno, uno.xModel, component);
+            if (model == null) {
+                return;
+            }
+            Object controller = invoke(model, "getCurrentController");
+            if (controller == null) {
+                return;
+            }
+            Object frame = invoke(controller, "getFrame");
+            if (frame == null) {
+                return;
+            }
+            Object xFrame = queryInterface(uno, uno.xFrame, frame);
+            if (xFrame == null) {
+                return;
+            }
+            Object containerWindow = queryInterface(uno, uno.xWindow, invoke(xFrame, "getContainerWindow"));
+            if (containerWindow == null) {
+                return;
+            }
+
+            invoke(containerWindow, "setVisible", Boolean.TRUE);
+            Rectangle currentBounds = getUnoWindowBounds(containerWindow);
+            if (!isWindowUsable(currentBounds)) {
+                Rectangle safeBounds = getSafeWindowBounds();
+                invoke(containerWindow, "setPosSize",
+                        Integer.valueOf(safeBounds.x),
+                        Integer.valueOf(safeBounds.y),
+                        Integer.valueOf(safeBounds.width),
+                        Integer.valueOf(safeBounds.height),
+                        getPosSizeAllFlag(uno));
+                log.debug("Normalized LibreOffice document window from " + currentBounds + " to " + safeBounds);
+            }
+            invoke(containerWindow, "setFocus");
+        } catch (Throwable t) {
+            log.debug("Could not normalize LibreOffice document window: " + t.getMessage(), t);
+        }
+    }
+
+    private static Rectangle getUnoWindowBounds(Object window) throws Exception {
+        Object bounds = invoke(window, "getPosSize");
+        return new Rectangle(
+                getIntField(bounds, "X"),
+                getIntField(bounds, "Y"),
+                getIntField(bounds, "Width"),
+                getIntField(bounds, "Height"));
+    }
+
+    private static int getIntField(Object object, String name) throws Exception {
+        Field field = object.getClass().getField(name);
+        return ((Number) field.get(object)).intValue();
+    }
+
+    private static Object getPosSizeAllFlag(UnoClasses uno) throws Exception {
+        Field field = uno.posSize.getField("POSSIZE");
+        return Short.valueOf(((Number) field.get(null)).shortValue());
+    }
+
+    private static boolean isWindowUsable(Rectangle bounds) {
+        if (bounds == null || bounds.width < MIN_WINDOW_WIDTH || bounds.height < MIN_WINDOW_HEIGHT) {
+            return false;
+        }
+
+        Rectangle screenBounds = getVirtualScreenBounds();
+        if (screenBounds == null) {
+            return true;
+        }
+        Rectangle visibleBounds = screenBounds.intersection(bounds);
+        return visibleBounds.width >= MIN_WINDOW_WIDTH / 2 && visibleBounds.height >= MIN_WINDOW_HEIGHT / 2;
+    }
+
+    private static Rectangle getSafeWindowBounds() {
+        Rectangle screenBounds = getVirtualScreenBounds();
+        if (screenBounds == null) {
+            return new Rectangle(100, 100, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
+        }
+
+        int width = Math.min(DEFAULT_WINDOW_WIDTH, Math.max(MIN_WINDOW_WIDTH, screenBounds.width - 100));
+        int height = Math.min(DEFAULT_WINDOW_HEIGHT, Math.max(MIN_WINDOW_HEIGHT, screenBounds.height - 100));
+        int x = screenBounds.x + Math.max(50, (screenBounds.width - width) / 2);
+        int y = screenBounds.y + Math.max(50, (screenBounds.height - height) / 2);
+        return new Rectangle(x, y, width, height);
+    }
+
+    private static Rectangle getVirtualScreenBounds() {
+        try {
+            GraphicsEnvironment environment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            Rectangle bounds = null;
+            for (GraphicsDevice device : environment.getScreenDevices()) {
+                Rectangle deviceBounds = device.getDefaultConfiguration().getBounds();
+                bounds = bounds == null ? new Rectangle(deviceBounds) : bounds.union(deviceBounds);
+            }
+            return bounds;
+        } catch (Throwable t) {
+            return null;
+        }
     }
 
     private static Object connect(UnoClasses uno, Object resolver, int port, Process process) throws Exception {
@@ -378,6 +509,10 @@ public class JavaUnoOfficeMonitor {
         private final Class<?> xCloseListener;
         private final Class<?> xModifyBroadcaster;
         private final Class<?> xModifyListener;
+        private final Class<?> xModel;
+        private final Class<?> xFrame;
+        private final Class<?> xWindow;
+        private final Class<?> posSize;
 
         UnoClasses(ClassLoader loader) throws Exception {
             this.loader = loader;
@@ -393,6 +528,10 @@ public class JavaUnoOfficeMonitor {
             this.xCloseListener = Class.forName("com.sun.star.util.XCloseListener", true, loader);
             this.xModifyBroadcaster = Class.forName("com.sun.star.util.XModifyBroadcaster", true, loader);
             this.xModifyListener = Class.forName("com.sun.star.util.XModifyListener", true, loader);
+            this.xModel = Class.forName("com.sun.star.frame.XModel", true, loader);
+            this.xFrame = Class.forName("com.sun.star.frame.XFrame", true, loader);
+            this.xWindow = Class.forName("com.sun.star.awt.XWindow", true, loader);
+            this.posSize = Class.forName("com.sun.star.awt.PosSize", true, loader);
         }
     }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java
@@ -9,6 +9,9 @@
  */
 package com.jdimension.jlawyer.client.launcher;
 
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Array;
@@ -39,6 +42,10 @@ public class JavaUnoOfficeMonitor {
     private static final String PROP_UNO_EXTRA_ARGS = "jlawyer.uno.extraArgs";
     private static final String PROP_UNO_PORT = "jlawyer.uno.port";
     private static final String ENV_UNO_CLASSPATH = "JLAWYER_UNO_CLASSPATH";
+    private static final int MIN_WINDOW_WIDTH = 800;
+    private static final int MIN_WINDOW_HEIGHT = 600;
+    private static final int DEFAULT_WINDOW_WIDTH = 1200;
+    private static final int DEFAULT_WINDOW_HEIGHT = 900;
 
     private JavaUnoOfficeMonitor() {
     }
@@ -81,6 +88,7 @@ public class JavaUnoOfficeMonitor {
             }
             componentLoaded = true;
 
+            normalizeDocumentWindow(uno, component);
             List<Object> listeners = registerListeners(uno, component, document);
             document.setUnoMonitorSession(new MonitorSession(unoClassLoader, process, resolver, remoteContext, component, listeners));
             document.setUnoMonitoringActive(true);
@@ -125,6 +133,120 @@ public class JavaUnoOfficeMonitor {
             listeners.add(modifyListener);
         }
         return listeners;
+    }
+
+    private static void normalizeDocumentWindow(UnoClasses uno, Object component) {
+        for (int attempt = 0; attempt < 5; attempt++) {
+            normalizeDocumentWindowOnce(uno, component);
+            if (attempt < 4) {
+                try {
+                    Thread.sleep(150);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private static void normalizeDocumentWindowOnce(UnoClasses uno, Object component) {
+        try {
+            Object model = queryInterface(uno, uno.xModel, component);
+            if (model == null) {
+                return;
+            }
+            Object controller = invoke(model, "getCurrentController");
+            if (controller == null) {
+                return;
+            }
+            Object frame = invoke(controller, "getFrame");
+            if (frame == null) {
+                return;
+            }
+            Object xFrame = queryInterface(uno, uno.xFrame, frame);
+            if (xFrame == null) {
+                return;
+            }
+            Object containerWindow = queryInterface(uno, uno.xWindow, invoke(xFrame, "getContainerWindow"));
+            if (containerWindow == null) {
+                return;
+            }
+
+            invoke(containerWindow, "setVisible", Boolean.TRUE);
+            Rectangle currentBounds = getUnoWindowBounds(containerWindow);
+            if (!isWindowUsable(currentBounds)) {
+                Rectangle safeBounds = getSafeWindowBounds();
+                invoke(containerWindow, "setPosSize",
+                        Integer.valueOf(safeBounds.x),
+                        Integer.valueOf(safeBounds.y),
+                        Integer.valueOf(safeBounds.width),
+                        Integer.valueOf(safeBounds.height),
+                        getPosSizeAllFlag(uno));
+                log.debug("Normalized LibreOffice document window from " + currentBounds + " to " + safeBounds);
+            }
+            invoke(containerWindow, "setFocus");
+        } catch (Throwable t) {
+            log.debug("Could not normalize LibreOffice document window: " + t.getMessage(), t);
+        }
+    }
+
+    private static Rectangle getUnoWindowBounds(Object window) throws Exception {
+        Object bounds = invoke(window, "getPosSize");
+        return new Rectangle(
+                getIntField(bounds, "X"),
+                getIntField(bounds, "Y"),
+                getIntField(bounds, "Width"),
+                getIntField(bounds, "Height"));
+    }
+
+    private static int getIntField(Object object, String name) throws Exception {
+        Field field = object.getClass().getField(name);
+        return ((Number) field.get(object)).intValue();
+    }
+
+    private static Object getPosSizeAllFlag(UnoClasses uno) throws Exception {
+        Field field = uno.posSize.getField("POSSIZE");
+        return Short.valueOf(((Number) field.get(null)).shortValue());
+    }
+
+    private static boolean isWindowUsable(Rectangle bounds) {
+        if (bounds == null || bounds.width < MIN_WINDOW_WIDTH || bounds.height < MIN_WINDOW_HEIGHT) {
+            return false;
+        }
+
+        Rectangle screenBounds = getVirtualScreenBounds();
+        if (screenBounds == null) {
+            return true;
+        }
+        Rectangle visibleBounds = screenBounds.intersection(bounds);
+        return visibleBounds.width >= MIN_WINDOW_WIDTH / 2 && visibleBounds.height >= MIN_WINDOW_HEIGHT / 2;
+    }
+
+    private static Rectangle getSafeWindowBounds() {
+        Rectangle screenBounds = getVirtualScreenBounds();
+        if (screenBounds == null) {
+            return new Rectangle(100, 100, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
+        }
+
+        int width = Math.min(DEFAULT_WINDOW_WIDTH, Math.max(MIN_WINDOW_WIDTH, screenBounds.width - 100));
+        int height = Math.min(DEFAULT_WINDOW_HEIGHT, Math.max(MIN_WINDOW_HEIGHT, screenBounds.height - 100));
+        int x = screenBounds.x + Math.max(50, (screenBounds.width - width) / 2);
+        int y = screenBounds.y + Math.max(50, (screenBounds.height - height) / 2);
+        return new Rectangle(x, y, width, height);
+    }
+
+    private static Rectangle getVirtualScreenBounds() {
+        try {
+            GraphicsEnvironment environment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            Rectangle bounds = null;
+            for (GraphicsDevice device : environment.getScreenDevices()) {
+                Rectangle deviceBounds = device.getDefaultConfiguration().getBounds();
+                bounds = bounds == null ? new Rectangle(deviceBounds) : bounds.union(deviceBounds);
+            }
+            return bounds;
+        } catch (Throwable t) {
+            return null;
+        }
     }
 
     private static Object connect(UnoClasses uno, Object resolver, int port, Process process) throws Exception {
@@ -378,6 +500,10 @@ public class JavaUnoOfficeMonitor {
         private final Class<?> xCloseListener;
         private final Class<?> xModifyBroadcaster;
         private final Class<?> xModifyListener;
+        private final Class<?> xModel;
+        private final Class<?> xFrame;
+        private final Class<?> xWindow;
+        private final Class<?> posSize;
 
         UnoClasses(ClassLoader loader) throws Exception {
             this.loader = loader;
@@ -393,6 +519,10 @@ public class JavaUnoOfficeMonitor {
             this.xCloseListener = Class.forName("com.sun.star.util.XCloseListener", true, loader);
             this.xModifyBroadcaster = Class.forName("com.sun.star.util.XModifyBroadcaster", true, loader);
             this.xModifyListener = Class.forName("com.sun.star.util.XModifyListener", true, loader);
+            this.xModel = Class.forName("com.sun.star.frame.XModel", true, loader);
+            this.xFrame = Class.forName("com.sun.star.frame.XFrame", true, loader);
+            this.xWindow = Class.forName("com.sun.star.awt.XWindow", true, loader);
+            this.posSize = Class.forName("com.sun.star.awt.PosSize", true, loader);
         }
     }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/LinuxOfficeLauncher.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/LinuxOfficeLauncher.java
@@ -702,6 +702,11 @@ public class LinuxOfficeLauncher extends OfficeLauncher {
                     odoc.setStatus(ObservedDocument.STATUS_LAUNCHING);
                     observer.addDocument(odoc);
 
+                    if (JavaUnoOfficeMonitor.launch(loBinary, url, odoc)) {
+                        odoc.setStatus(ObservedDocument.STATUS_OPEN);
+                        return;
+                    }
+
                     Process p = null;
                     boolean libreOffice = false;
                     try {

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/MacOfficeLauncher.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/MacOfficeLauncher.java
@@ -700,6 +700,11 @@ public class MacOfficeLauncher extends OfficeLauncher {
                 ServerSettings settings = ServerSettings.getInstance();
                 int waitForTime = settings.getSettingAsInt(ServerSettings.SERVERCONF_DOCUMENTS_WAITFOR_MAC, 4000);
                 
+                if (JavaUnoOfficeMonitor.launch(loBinary, url, odoc)) {
+                    odoc.setStatus(ObservedDocument.STATUS_OPEN);
+                    return;
+                }
+
                 Process p = null;
                 boolean libreOffice = false;
                 try {

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/ObservedOfficeDocument.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/ObservedOfficeDocument.java
@@ -673,10 +673,14 @@ import org.apache.log4j.Logger;
 public class ObservedOfficeDocument extends ObservedDocument {
 
     private static final Logger log = Logger.getLogger(ObservedOfficeDocument.class.getName());
+    private static final long UNLOCK_GRACE_PERIOD_MILLIS = 2l * DocumentObserverTask.getDefaultInterval();
 
     private long lastLocked = -1;
     private long unlockTime = -1;
     private String lockFile = null;
+    private volatile boolean unoMonitoringActive = false;
+    private volatile boolean unoCloseConfirmed = false;
+    private volatile JavaUnoOfficeMonitor.MonitorSession unoMonitorSession = null;
 
     public ObservedOfficeDocument(String path, ObservedDocumentStore store, Launcher l) {
         super(path, store, l);
@@ -717,8 +721,14 @@ public class ObservedOfficeDocument extends ObservedDocument {
                 }
                 long unlockedForDuration = System.currentTimeMillis() - this.unlockTime;
 
-                // temporary loss of lock?
-                if (unlockedForDuration > (2l * DocumentObserverTask.getDefaultInterval())) {
+                if (this.unoMonitoringActive && this.unoCloseConfirmed) {
+                    log.debug("UNO close confirmed and lock released - considering closed: " + this.path);
+                    return true;
+                }
+
+                // LibreOffice can briefly recreate the lock file while saving (#232).
+                // Keep a grace period, but do not tie the wait to the observer timer.
+                if (unlockedForDuration >= UNLOCK_GRACE_PERIOD_MILLIS) {
                     log.debug("file without lock for " + unlockedForDuration + " - considering closed: " + this.path);
                     return true;
                 } else {
@@ -726,12 +736,45 @@ public class ObservedOfficeDocument extends ObservedDocument {
                     return false;
                 }
             } else {
+                if (this.unoMonitoringActive && this.unoCloseConfirmed) {
+                    log.debug("UNO close confirmed before lock was observed - considering closed: " + this.path);
+                    return true;
+                }
                 log.debug("file not locked yet: " + this.path + " considering document as NOT closed");
                 return false;
             }
         }
         //return super.isClosed();
 
+    }
+
+    public void setUnoMonitoringActive(boolean unoMonitoringActive) {
+        this.unoMonitoringActive = unoMonitoringActive;
+    }
+
+    public boolean isUnoMonitoringActive() {
+        return unoMonitoringActive;
+    }
+
+    public void markUnoCloseConfirmed() {
+        this.unoCloseConfirmed = true;
+    }
+
+    public boolean isUnoCloseConfirmed() {
+        return unoCloseConfirmed;
+    }
+
+    public void setUnoMonitorSession(JavaUnoOfficeMonitor.MonitorSession unoMonitorSession) {
+        this.unoMonitorSession = unoMonitorSession;
+    }
+
+    public void closeUnoMonitorSession() {
+        JavaUnoOfficeMonitor.MonitorSession session = this.unoMonitorSession;
+        this.unoMonitorSession = null;
+        this.unoMonitoringActive = false;
+        if (session != null) {
+            session.release();
+        }
     }
 
 }

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/WindowsOfficeLauncher.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/WindowsOfficeLauncher.java
@@ -698,6 +698,12 @@ public class WindowsOfficeLauncher extends OfficeLauncher {
                 odoc.setStatus(ObservedDocument.STATUS_LAUNCHING);
                 observer.addDocument(odoc);
                 
+                if (JavaUnoOfficeMonitor.launch(oooBinary, url, odoc)) {
+                    log.debug("observer status open " + odoc.getName() + " via UNO");
+                    odoc.setStatus(ObservedDocument.STATUS_OPEN);
+                    return;
+                }
+
                 Process p = null;
                 boolean success = false;
                 try {

--- a/openspec/changes/add-uno-document-monitoring/design.md
+++ b/openspec/changes/add-uno-document-monitoring/design.md
@@ -1,0 +1,50 @@
+## Context
+j-lawyer currently launches LibreOffice/OpenOffice documents as external files and monitors LibreOffice's `.~lock.<file>#` sidecar file. A prior workaround for #232 intentionally waits after the lock disappears because some LibreOffice versions temporarily remove and recreate that file while the document is still open or saving.
+
+Java UNO testing on this workstation showed LibreOffice can emit document modify, `OnSaveDone`, close query, close notify, view closed, and unload events when j-lawyer starts LibreOffice with a UNO accept socket and loads the document through UNO. A normal LibreOffice process started without `--accept=...` exposes no socket to attach to.
+
+## Goals / Non-Goals
+- Goals:
+  - Reduce close-detection latency for LibreOffice documents opened by j-lawyer.
+  - Preserve #232 data-loss protection for lock-file-only monitoring.
+  - Keep behavior functional when UNO Java support is missing.
+- Non-Goals:
+  - Attach to arbitrary already-running LibreOffice instances not started with a UNO accept socket.
+  - Replace all office launchers in one step.
+  - Remove lock-file monitoring.
+
+## Decisions
+- Decision: Use hybrid confirmation.
+  - If UNO close/unload has been observed and the lock file is gone, close immediately.
+  - If the lock file is gone without UNO close/unload confirmation, use the existing grace-period fallback.
+  - If UNO close/unload is observed while the lock file still exists, wait for lock removal without adding the grace period afterward.
+- Decision: Make UNO optional.
+  - The launcher attempts UNO only when Java UNO classes and a usable LibreOffice binary are available.
+  - UNO discovery must support both legacy split jars such as `juh.jar` / `unoil.jar` and modern `libreoffice.jar` packaging.
+  - Any UNO startup, connection, listener, or bridge failure falls back to the current process/lock-file monitoring path.
+- Decision: Scope UNO session lifetime to the observed document.
+  - The observed document keeps strong references to the UNO bridge objects, classloader, process handle, component, and listener proxies while monitoring is active.
+  - The observer releases the UNO classloader when it processes the document as closed.
+  - Normal close cleanup does not destroy the LibreOffice process, because without an isolated user profile it may be the user's shared LibreOffice instance.
+- Decision: Keep lock-file writes authoritative for disk release.
+  - UNO close events prove user/document lifecycle, while lock-file disappearance proves LibreOffice has released the file for safe import.
+
+## Risks / Trade-offs
+- Java UNO packaging differs by OS and LibreOffice installation.
+  - Mitigation: discovery plus fallback to current launcher.
+- Starting LibreOffice with a UNO socket changes launcher internals.
+  - Mitigation: keep the change scoped to LibreOffice/OpenOffice launcher paths and preserve existing process launch fallback.
+- Existing LibreOffice instances may ignore the requested accept socket.
+  - Mitigation: if the launched process exits before the UNO socket accepts connections, fail fast and use the existing lock-file launcher path.
+- UNO bridge disconnects or LibreOffice crashes can leave incomplete event state.
+  - Mitigation: treat disconnect/crash as no UNO confirmation and use lock-file fallback.
+
+## Migration Plan
+1. Add UNO monitor classes behind optional runtime detection.
+2. Wire LibreOffice launcher to use UNO loading when available.
+3. Preserve and test lock-file fallback.
+4. Consider packaging Java UNO jars or installer dependency changes after confirming target-platform availability.
+
+## Open Questions
+- Should the client bundle LibreOffice Java UNO jars or require the installed LibreOffice Java support package?
+- Should the UNO accept socket use localhost TCP with a random port or a named pipe where supported?

--- a/openspec/changes/add-uno-document-monitoring/proposal.md
+++ b/openspec/changes/add-uno-document-monitoring/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add UNO-backed LibreOffice document monitoring
+
+## Why
+LibreOffice documents can remain marked as open for several seconds after the user closes them because j-lawyer must debounce lock-file disappearance to avoid the historic data-loss bug #232. Java UNO can provide semantic save and close events for LibreOffice documents opened by j-lawyer, allowing near-immediate close detection when those events agree with lock-file release.
+
+## What Changes
+- Add optional Java UNO monitoring for LibreOffice/OpenOffice documents launched by the desktop client.
+- Treat a document as closed immediately when both a UNO close/unload event and LibreOffice lock-file removal have been observed.
+- Preserve the existing lock-file grace period when UNO is unavailable, fails, disconnects, or has not confirmed close.
+- Keep current lock-file monitoring as the compatibility fallback.
+- Add focused tests/harness coverage for UNO event handling and lock-file fallback behavior.
+
+## Impact
+- Affected specs: document-monitoring
+- Affected code:
+  - `j-lawyer-client/src/com/jdimension/jlawyer/client/launcher/*Office*`
+  - `j-lawyer-client/src/com/jdimension/jlawyer/client/launcher/ObservedOfficeDocument.java`
+  - `j-lawyer-client/src/com/jdimension/jlawyer/client/editors/files/WaitForDocumentAction.java`
+- External dependency consideration: Java UNO runtime jars (`juh`, `jurt`, `ridl`, `unoil`, `java_uno`/LibreOffice Java support) must be discovered or bundled/declared for the client runtime; fallback remains available when absent.

--- a/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
+++ b/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
@@ -26,9 +26,3 @@ The desktop client SHALL support optional UNO-backed close detection for LibreOf
 - **WHEN** the client monitors the document lifecycle
 - **THEN** the client SHALL use lock-file monitoring with the grace period
 - **AND** document save/close handling SHALL continue without requiring UNO
-
-#### Scenario: UNO launch avoids unusable restored window geometry
-- **GIVEN** LibreOffice has saved a tiny or off-screen document window state
-- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
-- **THEN** the client SHALL make the document window visible
-- **AND** if the restored document window is too small or outside the available desktop, the client SHALL move and resize it to usable bounds

--- a/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
+++ b/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
@@ -26,3 +26,9 @@ The desktop client SHALL support optional UNO-backed close detection for LibreOf
 - **WHEN** the client monitors the document lifecycle
 - **THEN** the client SHALL use lock-file monitoring with the grace period
 - **AND** document save/close handling SHALL continue without requiring UNO
+
+#### Scenario: UNO launch avoids unusable restored window geometry
+- **GIVEN** LibreOffice has saved a tiny or off-screen document window state
+- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
+- **THEN** the client SHALL make the document window visible
+- **AND** if the restored document window is too small or outside the available desktop, the client SHALL move and resize it to usable bounds

--- a/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
+++ b/openspec/changes/add-uno-document-monitoring/specs/document-monitoring/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+### Requirement: Hybrid LibreOffice Close Detection
+The desktop client SHALL support optional UNO-backed close detection for LibreOffice/OpenOffice documents opened by j-lawyer while retaining lock-file monitoring as the fallback.
+
+#### Scenario: UNO close and lock removal close immediately
+- **GIVEN** a LibreOffice document opened by j-lawyer has active UNO monitoring
+- **WHEN** the client observes a UNO close or unload event for that document
+- **AND** the corresponding `.~lock.<filename>#` file is absent
+- **THEN** the document SHALL be treated as closed without waiting for the lock-file grace period
+
+#### Scenario: UNO close before lock removal waits for disk release
+- **GIVEN** a LibreOffice document opened by j-lawyer has active UNO monitoring
+- **WHEN** the client observes a UNO close or unload event for that document
+- **AND** the corresponding `.~lock.<filename>#` file still exists
+- **THEN** the document SHALL remain open until the lock file is absent
+- **AND** once the lock file is absent, the document SHALL be treated as closed without an additional grace period
+
+#### Scenario: Lock-only close keeps grace period
+- **GIVEN** a LibreOffice document opened by j-lawyer has no active UNO close confirmation
+- **WHEN** the corresponding `.~lock.<filename>#` file becomes absent
+- **THEN** the document SHALL remain open until the configured lock-file grace period has elapsed
+- **AND** if the lock file reappears during the grace period, the document SHALL remain open
+
+#### Scenario: UNO failure falls back to lock monitoring
+- **GIVEN** Java UNO support is unavailable or a UNO bridge fails while a LibreOffice document is open
+- **WHEN** the client monitors the document lifecycle
+- **THEN** the client SHALL use lock-file monitoring with the grace period
+- **AND** document save/close handling SHALL continue without requiring UNO

--- a/openspec/changes/add-uno-document-monitoring/tasks.md
+++ b/openspec/changes/add-uno-document-monitoring/tasks.md
@@ -5,7 +5,6 @@
 - [x] 1.4 Implement hybrid close logic: UNO close/unload plus lock-file removal closes immediately; lock-only uses grace period.
 - [x] 1.5 Wire LibreOffice/OpenOffice launchers to attempt UNO monitoring and fall back to existing launch behavior.
 - [x] 1.6 Keep `WaitForDocumentAction` actively refreshing observer state while it waits.
-- [x] 1.7 Normalize unusable LibreOffice document window bounds after UNO launch.
 
 ## 2. Verification
 - [x] 2.1 Add or keep a Java harness/test proving UNO modify/save/close events are observed on a real ODT.

--- a/openspec/changes/add-uno-document-monitoring/tasks.md
+++ b/openspec/changes/add-uno-document-monitoring/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+- [x] 1.1 Add a small UNO monitor/launcher helper that can start/connect to LibreOffice with an accept socket and load a document.
+- [x] 1.2 Register UNO document listeners for close/unload confirmation, close notifications, and modify-event logging.
+- [x] 1.3 Extend `ObservedOfficeDocument` with optional UNO close confirmation state.
+- [x] 1.4 Implement hybrid close logic: UNO close/unload plus lock-file removal closes immediately; lock-only uses grace period.
+- [x] 1.5 Wire LibreOffice/OpenOffice launchers to attempt UNO monitoring and fall back to existing launch behavior.
+- [x] 1.6 Keep `WaitForDocumentAction` actively refreshing observer state while it waits.
+
+## 2. Verification
+- [x] 2.1 Add or keep a Java harness/test proving UNO modify/save/close events are observed on a real ODT.
+- [x] 2.2 Test fallback behavior when Java UNO classes are unavailable.
+- [x] 2.3 Test lock-only grace behavior for #232 protection.
+- [x] 2.4 Compile the touched client classes.
+- [x] 2.5 Run the current Maven reactor build in Docker after seeding the local repository; note that client compilation is currently blocked by unrelated missing JavaFX, Nextcloud, and Mustang dependencies.

--- a/openspec/changes/add-uno-document-monitoring/tasks.md
+++ b/openspec/changes/add-uno-document-monitoring/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.4 Implement hybrid close logic: UNO close/unload plus lock-file removal closes immediately; lock-only uses grace period.
 - [x] 1.5 Wire LibreOffice/OpenOffice launchers to attempt UNO monitoring and fall back to existing launch behavior.
 - [x] 1.6 Keep `WaitForDocumentAction` actively refreshing observer state while it waits.
+- [x] 1.7 Normalize unusable LibreOffice document window bounds after UNO launch.
 
 ## 2. Verification
 - [x] 2.1 Add or keep a Java harness/test proving UNO modify/save/close events are observed on a real ODT.

--- a/openspec/changes/add-uno-window-normalization/proposal.md
+++ b/openspec/changes/add-uno-window-normalization/proposal.md
@@ -1,0 +1,31 @@
+# Change: Normalize unusable LibreOffice document window geometry
+
+## Why
+LibreOffice persists per-document-type window geometry in its user profile
+(`ooSetupFactoryWindowAttributes`). A known LibreOffice defect can save a tiny or
+off-screen "restored" geometry after a maximized window is closed. When j-lawyer then
+opens a document, LibreOffice recreates the window with that bad geometry, so the
+document appears as a barely-visible sliver or off-screen and effectively invisible.
+The user cannot interact with it, and j-lawyer's lock-file detection subsequently reports
+the document as already open, breaking the workflow (issue #3483). LibreOffice provides
+no CLI flag to override window geometry, so the only profile-preserving, reliably
+cross-environment mitigation is to correct the live window through UNO.
+
+## What Changes
+- After a UNO-launched LibreOffice document loads, ensure its container window is visible.
+- Detect an unusable window (too small, or too little of it intersects the desktop) and
+  move/resize it to safe, centered bounds on the active display.
+- Apply the correction with a short bounded retry, because LibreOffice restores the bad
+  geometry asynchronously after the document loads.
+- Keep the behavior non-fatal: any failure to inspect or adjust the window SHALL NOT
+  prevent the document from opening or UNO close monitoring from running.
+- This mitigation only applies on the UNO launch path; the non-UNO fallback launch is
+  unchanged.
+
+## Impact
+- Affected specs: document-monitoring
+- Affected code:
+  - `j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/launcher/JavaUnoOfficeMonitor.java`
+- Depends on the UNO launch path introduced by `add-uno-document-monitoring`.
+- Upstream: the root cause is a LibreOffice geometry-persistence defect; this change is a
+  client-side workaround, not a fix of LibreOffice itself.

--- a/openspec/changes/add-uno-window-normalization/specs/document-monitoring/spec.md
+++ b/openspec/changes/add-uno-window-normalization/specs/document-monitoring/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+### Requirement: Usable LibreOffice Document Window Geometry
+When the desktop client opens a LibreOffice document through the UNO launch path, it SHALL
+ensure the document window is visible and usable, correcting persisted geometry that would
+otherwise leave the window too small or off-screen. This correction SHALL be best-effort and
+SHALL NOT prevent the document from opening or UNO close monitoring from running.
+
+#### Scenario: Tiny restored window is resized to usable bounds
+- **GIVEN** LibreOffice has persisted a document window geometry smaller than the usable minimum
+- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
+- **THEN** the client SHALL make the document window visible
+- **AND** the client SHALL move and resize the window to usable bounds on the active display
+
+#### Scenario: Off-screen restored window is moved onto the desktop
+- **GIVEN** LibreOffice has persisted a document window position that leaves too little of the window intersecting the available desktop
+- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
+- **THEN** the client SHALL move and resize the window to usable bounds on the active display
+
+#### Scenario: Usable restored window is left unchanged
+- **GIVEN** LibreOffice has persisted a document window geometry that is large enough and sufficiently on-screen
+- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
+- **THEN** the client SHALL make the document window visible
+- **AND** the client SHALL NOT move or resize the window
+
+#### Scenario: Normalization failure does not block document opening
+- **GIVEN** the client cannot inspect or adjust the LibreOffice document window
+- **WHEN** j-lawyer opens a LibreOffice document with active UNO launching
+- **THEN** the document SHALL still open
+- **AND** UNO close monitoring SHALL continue as normal

--- a/openspec/changes/add-uno-window-normalization/tasks.md
+++ b/openspec/changes/add-uno-window-normalization/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+- [x] 1.1 After UNO `loadComponentFromURL`, resolve the document's container window via `XModel` → `XController` → `XFrame` → `XWindow`.
+- [x] 1.2 Make the container window visible and read its current bounds.
+- [x] 1.3 Treat the window as unusable when it is below a minimum size or too little of it intersects the virtual desktop.
+- [x] 1.4 When unusable, move/resize the window to safe centered bounds on the active display via `setPosSize` with `PosSize.POSSIZE`.
+- [x] 1.5 Retry the check briefly to defeat LibreOffice restoring the bad geometry asynchronously.
+- [x] 1.6 Keep every step non-fatal so document opening and UNO close monitoring continue on failure.
+
+## 2. Verification
+- [ ] 2.1 With a corrupted profile geometry (tiny/off-screen `ooSetupFactoryWindowAttributes`), confirm the opened document window appears at usable size on screen.
+- [ ] 2.2 Confirm a normally-sized restored window is left unchanged (no forced resize).
+- [ ] 2.3 Confirm document opening and close detection still work when window normalization throws.
+- [ ] 2.4 Compile the touched client class.


### PR DESCRIPTION
## Summary

Workaround for #3483: a LibreOffice document opened by j-lawyer sometimes appears as a
tiny, barely-visible sliver or off-screen and effectively invisible. LibreOffice can
persist a corrupted "restored" window geometry (`ooSetupFactoryWindowAttributes`) after a
maximized window is closed; the next document window is then created with that bad
geometry, and j-lawyer's lock-file check subsequently reports the document as already
open, breaking the workflow.

**The root cause is a LibreOffice defect, not a j-lawyer bug.** This PR is a temporary,
best-effort client-side mitigation that should be removable once LibreOffice fixes the
geometry persistence upstream (see the related upstream reports, e.g.
[tdf#125543](https://bugs.documentfoundation.org/show_bug.cgi?id=125543)).

## What it does

On the **UNO launch path only**, after `loadComponentFromURL`:

- Resolve the document container window (`XModel` → `XController` → `XFrame` → `XWindow`).
- Make it visible.
- If the window is unusable — below a minimum size, or too little of it intersects the
  desktop — move/resize it to safe, centered bounds on the active display.
- Retry briefly, because LibreOffice restores the bad geometry asynchronously.

Every step is best-effort: any failure to inspect or adjust the window leaves document
opening and UNO close monitoring completely unaffected. The non-UNO fallback launch path
is unchanged.

## Scope / relationship to other PRs

- **Stacked on #3472** (UNO close detection). This change depends on the
  `JavaUnoOfficeMonitor` introduced there, so this branch is based on
  `fix/libreoffice-document-close-monitor`. Until #3472 merges, the diff/commit list here
  will also show #3472's commits — the only new commit in this PR is the window
  normalization one.
- Deliberately kept separate from #3472 (an earlier attempt that folded this into #3472
  was reverted for exactly that reason). Tracked as its own openspec change,
  `add-uno-window-normalization`.

## Verification status

- Not yet runtime-verified (opening a document and observing the window land at a usable
  size requires a client build). The logic is the same that previously compiled before
  being reverted for scope reasons, so compile risk is low.
- Draft until built and confirmed.

Relates to #3483.
