### PR TITLE
Kontroll-Abfrage beim Erledigen einer Frist im Akten-Kalender (#3349)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel.properties
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel.properties
@@ -15,5 +15,7 @@ caption.followup=Wiedervorlage
 caption.respite=FRIST
 msg.error=Fehler
 dialog.confirm.setdone.title=Frist erledigt?
+dialog.confirm.setdone.multiple={0} Fristen auf erledigt setzen?\n{1}
+dialog.confirm.setdone.multiple.title=Fristen erledigt?
 dialog.confirm.lastopen=Letzter offener Kalendereintrag der Akte {0} {1}. Trotzdem schlie\u00dfen?
 dialog.confirm.lastopen.title=Warnung

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel_en.properties
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel_en.properties
@@ -15,5 +15,7 @@ caption.followup=Follow Up
 caption.respite=RESPITE
 msg.error=Error
 dialog.confirm.setdone.title=Respite done?
+dialog.confirm.setdone.multiple=Set {0} respites to done?\n{1}
+dialog.confirm.setdone.multiple.title=Respites done?
 dialog.confirm.lastopen=This is the last open calendar entry of case {0} {1}. Close anyway?
 dialog.confirm.lastopen.title=Warning

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -762,6 +762,7 @@ import com.jdimension.jlawyer.ui.folders.DocumentEntryPanel;
 import com.jdimension.jlawyer.ui.tagging.ArchiveFileTagActionListener;
 import com.jdimension.jlawyer.ui.tagging.DocumentTagActionListener;
 import com.jdimension.jlawyer.ui.tagging.TagSelectedAction;
+import com.jdimension.jlawyer.server.constants.ArchiveFileConstants;
 import com.jdimension.jlawyer.server.constants.OptionConstants;
 import com.jdimension.jlawyer.ui.tagging.MultiValueTag;
 import com.jdimension.jlawyer.ui.tagging.TagToggleButton;
@@ -6258,6 +6259,12 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
                 // click on checkbox in table
                 int row = this.tblReviewReasons.rowAtPoint(p);
                 ArchiveFileReviewsBean reviewDto = (ArchiveFileReviewsBean) this.tblReviewReasons.getValueAt(row, 0);
+                if (!reviewDto.isDone() && reviewDto.getEventType() == ArchiveFileConstants.REVIEWTYPE_RESPITE) {
+                    int response = JOptionPane.showConfirmDialog(this, java.text.MessageFormat.format(java.util.ResourceBundle.getBundle("com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel").getString("dialog.confirm.setdone"), new Object[]{reviewDto.getSummary()}), java.util.ResourceBundle.getBundle("com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel").getString("dialog.confirm.setdone.title"), JOptionPane.YES_NO_OPTION);
+                    if (response != JOptionPane.YES_OPTION) {
+                        return;
+                    }
+                }
                 reviewDto.setDone(!reviewDto.isDone());
 
                 ClientSettings settings = ClientSettings.getInstance();

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -4730,6 +4730,32 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
         EditorsRegistry.getInstance().updateStatus("Wiedervorlage/Frist wird gespeichert...");
 
         int[] selectedRows = this.tblReviewReasons.getSelectedRows();
+
+        java.util.List<ArchiveFileReviewsBean> openRespites = new ArrayList<>();
+        for (int i = 0; i < selectedRows.length; i++) {
+            ArchiveFileReviewsBean review = (ArchiveFileReviewsBean) this.tblReviewReasons.getValueAt(selectedRows[i], 0);
+            if (!review.isDone() && review.getEventType() == ArchiveFileConstants.REVIEWTYPE_RESPITE) {
+                openRespites.add(review);
+            }
+        }
+        if (!openRespites.isEmpty()) {
+            java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanel");
+            int response;
+            if (openRespites.size() == 1) {
+                response = JOptionPane.showConfirmDialog(this, java.text.MessageFormat.format(bundle.getString("dialog.confirm.setdone"), new Object[]{openRespites.get(0).getSummary()}), bundle.getString("dialog.confirm.setdone.title"), JOptionPane.YES_NO_OPTION);
+            } else {
+                StringBuilder reasons = new StringBuilder();
+                for (ArchiveFileReviewsBean r : openRespites) {
+                    reasons.append("- ").append(r.getSummary()).append(System.lineSeparator());
+                }
+                response = JOptionPane.showConfirmDialog(this, java.text.MessageFormat.format(bundle.getString("dialog.confirm.setdone.multiple"), new Object[]{openRespites.size(), reasons.toString()}), bundle.getString("dialog.confirm.setdone.multiple.title"), JOptionPane.YES_NO_OPTION);
+            }
+            if (response != JOptionPane.YES_OPTION) {
+                EditorsRegistry.getInstance().clearStatus();
+                return;
+            }
+        }
+
         ArchiveFileReviewsBean relevantEvent = null;
         for (int i = 0; i < selectedRows.length; i++) {
 


### PR DESCRIPTION
Implementiert #3349: Beim Erledigen einer Frist im Akten-Kalender erscheint jetzt dieselbe Kontroll-Abfrage wie auf dem Desktop.

## Änderungen

- **Checkbox in der Kalender-Tabelle** (`tblReviewReasonsMouseClicked`): Beim Übergang offen → erledigt einer Frist (`REVIEWTYPE_RESPITE`) erscheint die Abfrage „Frist ‚…' auf erledigt setzen?" (identischer Wortlaut und Bundle wie auf dem Desktop). Bei „Nein" passiert nichts. Das Zurücksetzen auf „offen" bleibt wie bisher ohne Abfrage.
- **Kontextmenü „erledigt"** (`mnuSetReviewDoneActionPerformed`): Offene Fristen in der Auswahl werden vor dem Speichern gesammelt. Bei einer Frist erscheint die Einzelabfrage, bei mehreren eine Sammelabfrage mit Aufzählung der Fristgründe. Bei „Nein" wird die gesamte Aktion abgebrochen, bevor irgendein Eintrag geändert wird. Wiedervorlagen und Termine lösen keine Abfrage aus.
- **Sprachdateien**: Zwei neue Keys `dialog.confirm.setdone.multiple` / `dialog.confirm.setdone.multiple.title` in `ReviewDueEntryPanel.properties` (de + en). Die Einzelabfrage nutzt die vorhandenen Keys, damit die Texte mit dem Desktop synchron bleiben.

Keine Änderungen an `.form`-Dateien (GUI-Builder-kompatibel), keine Server-/API-Änderungen.

## Testhinweise (manuelle Verifikation)

Automatisierte UI-Tests existieren für diesen Bereich nicht; zur Prüfung:

- Frist per Checkbox erledigen → Abfrage; „Nein" ändert nichts, „Ja" erledigt.
- Mehrfachauswahl (Fristen + Wiedervorlage) per Kontextmenü → Sammelabfrage nennt nur die Fristen; „Nein" bricht komplett ab.
- Wiedervorlage/Termin erledigen → keine Abfrage.
- Erledigte Frist wieder öffnen → keine Abfrage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
