### PR TITLE
Wochentag vor dem Fälligkeitsdatum von Kalendereinträgen (#507)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanelTransparent.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/desktop/ReviewDueEntryPanelTransparent.java
@@ -1252,7 +1252,7 @@ public class ReviewDueEntryPanelTransparent extends javax.swing.JPanel {
             this.chkDescription.setSelected(postPonedDone);
 
             // Show the new date in the label so user can verify their selection
-            SimpleDateFormat dfDisplay = new SimpleDateFormat("dd.MM.yyyy");
+            SimpleDateFormat dfDisplay = new SimpleDateFormat("EEEE, dd.MM.yyyy");
             String newDateStr = dfDisplay.format(d);
             String reason = e.getReviewReason();
             if (reason == null || reason.isEmpty()) {

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsAdvancedSearchThread.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsAdvancedSearchThread.java
@@ -790,7 +790,7 @@ public class ArchiveFileReviewsAdvancedSearchThread implements Runnable {
         }
         TableRowSorter<TableModel> sorter = new TableRowSorter<>(model);
         sorter.setComparator(2, new FileNumberComparatorString());
-        sorter.setComparator(0, new DateStringComparator());
+        sorter.setComparator(0, new DateStringComparator("EEEE, dd.MM.yyyy"));
         ThreadUtils.setTableModel(this.target, model, sorter);
         ThreadUtils.setDefaultCursor(this.owner);
         // give the EDT some time to process the new table model

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsSearchThread.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFileReviewsSearchThread.java
@@ -752,7 +752,7 @@ public class ArchiveFileReviewsSearchThread implements Runnable {
         }
         TableRowSorter<TableModel> sorter = new TableRowSorter<>(model);
         sorter.setComparator(2, new FileNumberComparatorString());
-        sorter.setComparator(0, new DateStringComparator());
+        sorter.setComparator(0, new DateStringComparator("EEEE, dd.MM.yyyy"));
         ThreadUtils.setTableModel(this.target, model, sorter);
         if (this.calendarTarget != null) {
             ThreadUtils.setCalendarItems(this.calendarTarget, dtos);

--- a/j-lawyer-server-entities/src/main/java/com/jdimension/jlawyer/persistence/ArchiveFileReviewsBean.java
+++ b/j-lawyer-server-entities/src/main/java/com/jdimension/jlawyer/persistence/ArchiveFileReviewsBean.java
@@ -820,9 +820,9 @@ public class ArchiveFileReviewsBean implements Serializable, EventTypes {
 
     @Override
     public String toString() {
-        SimpleDateFormat dateTimeFormat = new SimpleDateFormat("dd.MM.yyyy HH:mm");
+        SimpleDateFormat dateTimeFormat = new SimpleDateFormat("EEEE, dd.MM.yyyy HH:mm");
         SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm");
-        SimpleDateFormat dateFormat = new SimpleDateFormat("dd.MM.yyyy");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("EEEE, dd.MM.yyyy");
         return toString(dateTimeFormat, dateFormat, timeFormat);
     }
     


### PR DESCRIPTION
Closes #507

## Änderungen

- Fälligkeitsdaten von Fristen/Wiedervorlagen/Terminen zeigen jetzt den Wochentag: "Montag, 17.07.2026" bzw. "Montag, 17.07.2026 14:30". Zentral umgesetzt in der parameterlosen `ArchiveFileReviewsBean.toString()` — wirkt damit auf Desktop-Kacheln, den Kalender-Tab der Akte, "Fristen suchen" und die fällige/überfällige-Übersicht.
- Sortier-Fix: Die Spalte "Datum / Zeit" der beiden Suchtabellen parst den Zellentext zum Sortieren (`DateStringComparator`); beide Aufrufe nutzen jetzt das neue Muster, damit die chronologische Sortierung erhalten bleibt.
- Das Bestätigungs-Label nach dem Verschieben einer WV auf dem Desktop zeigt ebenfalls den Wochentag.

## Nicht geändert

- Druckpfad (`PrintStubGenerator` nutzt die parametrisierte `toString`-Überladung): Druckstücke bleiben ohne Wochentag.
- Die Parse-Stelle für Nutzereingaben im Verschieben-Dialog.

Manuelle Verifikation in NetBeans (Anzeige + Spaltensortierung) erfolgt nachgelagert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
