### PR TITLE
Fristen-Bearbeitungsdialog: erledigt-Status erhalten und setzbar, Label für Kalenderauswahl (#1680, #1681)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/EditOrDuplicateEventDialog.form
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/EditOrDuplicateEventDialog.form
@@ -51,6 +51,8 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="cmbReviewReason" max="32767" attributes="0"/>
                   <Group type="102" alignment="1" attributes="0">
+                      <Component id="chkEventDone" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
                       <Component id="cmdOK" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="cmdCancel" min="-2" max="-2" attributes="0"/>
@@ -59,6 +61,8 @@
                   <Group type="102" alignment="0" attributes="0">
                       <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
+                      <Component id="lblCalendar" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
                       <Component id="calendarSelectionButton1" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" attributes="0">
@@ -120,7 +124,10 @@
                       <EmptySpace min="-2" pref="8" max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="1" attributes="0">
-                      <Component id="calendarSelectionButton1" min="-2" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="calendarSelectionButton1" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="lblCalendar" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
                       <EmptySpace max="-2" attributes="0"/>
                   </Group>
               </Group>
@@ -176,6 +183,7 @@
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="cmdOK" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="cmdCancel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="chkEventDone" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace min="-2" pref="20" max="-2" attributes="0"/>
           </Group>
@@ -441,6 +449,16 @@
         <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
           <Image iconType="3" name="/icons16/material/notifications_off.png"/>
         </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="chkEventDone">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="erledigt"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="lblCalendar">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Kalender:"/>
       </Properties>
     </Component>
   </SubComponents>

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/EditOrDuplicateEventDialog.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/EditOrDuplicateEventDialog.java
@@ -771,8 +771,7 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
         updateReminderIcon();
         if (this.mode == MODE_EDIT) {
             targetReview.setId(rev.getId());
-            targetReview.setDone(false);
-
+            this.chkEventDone.setSelected(rev.isDone());
         }
 
         CalendarUtils.populateCalendarEntryTemplatesDropdown(this.cmbReviewReason, true);
@@ -892,6 +891,8 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
         cmbEventEndTime = new javax.swing.JComboBox<>();
         calendarSelectionButton1 = new com.jdimension.jlawyer.client.calendar.CalendarSelectionButton();
         cmdReminder = new javax.swing.JButton();
+        chkEventDone = new javax.swing.JCheckBox();
+        lblCalendar = new javax.swing.JLabel();
 
         jTextArea1.setColumns(20);
         jTextArea1.setRows(5);
@@ -974,6 +975,10 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
 
         cmdReminder.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/material/notifications_off.png"))); // NOI18N
 
+        chkEventDone.setText("erledigt");
+
+        lblCalendar.setText("Kalender:");
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
@@ -983,6 +988,8 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(cmbReviewReason, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                        .addComponent(chkEventDone)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(cmdOK)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(cmdCancel))
@@ -990,6 +997,8 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(jLabel1)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(lblCalendar)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(calendarSelectionButton1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -1036,7 +1045,9 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
                         .addComponent(jLabel1)
                         .addGap(8, 8, 8))
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                        .addComponent(calendarSelectionButton1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(calendarSelectionButton1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(lblCalendar))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)))
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                     .addGroup(layout.createSequentialGroup()
@@ -1076,7 +1087,8 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(cmdOK)
-                    .addComponent(cmdCancel))
+                    .addComponent(cmdCancel)
+                    .addComponent(chkEventDone))
                 .addGap(20, 20, 20))
         );
 
@@ -1122,7 +1134,7 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
             return;
         }
 
-        targetReview.setDone(false);
+        targetReview.setDone(this.chkEventDone.isSelected());
         targetReview.setBeginDate(beginDate);
         targetReview.setEndDate(endDate);
         targetReview.setSummary(this.cmbReviewReason.getEditor().getItem().toString());
@@ -1250,6 +1262,7 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
     }
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private com.jdimension.jlawyer.client.calendar.CalendarSelectionButton calendarSelectionButton1;
+    private javax.swing.JCheckBox chkEventDone;
     private javax.swing.JComboBox cmbAssignee;
     private javax.swing.JComboBox<String> cmbEventBeginTime;
     private javax.swing.JComboBox<String> cmbEventEndTime;
@@ -1267,6 +1280,7 @@ public class EditOrDuplicateEventDialog extends javax.swing.JDialog {
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JScrollPane jScrollPane2;
     private javax.swing.JTextArea jTextArea1;
+    private javax.swing.JLabel lblCalendar;
     private com.jdimension.jlawyer.client.components.QuickDateSelectionPanel quickDateSelectionPanel;
     private javax.swing.JTextArea taEventDescription;
     private javax.swing.JTextField txtEventBeginDateField;


### PR DESCRIPTION
Closes #1680
Closes #1681

## Änderungen

- **Bugfix (#1680):** Das Bearbeiten eines Kalendereintrags setzte den erledigt-Status stillschweigend zurück auf "offen" (`setDone(false)` beim Befüllen und Speichern). Jetzt zeigt eine neue Checkbox "erledigt" (unten links im Dialog) den aktuellen Status an; beim Speichern gilt der Checkbox-Wert.
- **Duplizieren:** startet weiterhin mit "offen" (Checkbox leer).
- **#1681:** Die Kalender-Farbauswahl rechts oben hat jetzt ein Label "Kalender:".
- `.java` (GUI-Builder-GEN-Block) und `.form` wurden synchron geändert; die Form wurde in NetBeans gegengeprüft (GUI-Builder lädt sie fehlerfrei).

## Abgrenzung

Keine Kontroll-Abfrage beim Setzen des Hakens im Dialog — anders als der Ein-Klick-Haken in der Kalendertabelle (#3349 / PR #3490) ist das Speichern im Dialog eine bewusste, explizite Aktion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
