### PR TITLE
Geburtsdatum im Tooltip des U18-Symbols (#3211)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/InvolvedPartyEntryPanel.java
@@ -822,7 +822,7 @@ public class InvolvedPartyEntryPanel extends javax.swing.JPanel implements Event
                 if (age < 18 && age > -1) {
                     this.lblUnderage.setIcon(new javax.swing.ImageIcon(getClass().getResource("/icons16/material/baseline_child_care_black_20.png")));
                     this.lblUnderage.setText("U18");
-                    this.lblUnderage.setToolTipText("Beteiligte(r) ist minderjährig");
+                    this.lblUnderage.setToolTipText("Beteiligte(r) ist minderjährig (geboren: " + a.getBirthDate() + ")");
                 }
             }
 


### PR DESCRIPTION
Closes #3211

## Änderungen

Der Tooltip des U18-Symbols im Beteiligtenbereich zeigt jetzt das Geburtsdatum: "Beteiligte(r) ist minderjährig (geboren: 12.03.2015)". Damit ist das im Familien-/Erbrecht ständig benötigte Geburtsdatum per Mouseover erreichbar, ohne in die Adresse klicken zu müssen.

Symbol und "U18"-Text bleiben unverändert; der Adress-Editor zeigt das Geburtsdatum weiterhin wie bisher.

Manuelle Verifikation in NetBeans erfolgt nachgelagert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
