### PR TITLE
Rückfrage-Dialoge: Notizen-Editor, E-Mail-Vorlagen, beA-Ausgang beim Beenden (#3204, #3201, #2743)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/JKanzleiGUI.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/JKanzleiGUI.java
@@ -2414,7 +2414,12 @@ public class JKanzleiGUI extends javax.swing.JFrame implements com.jdimension.jl
                     }
                 }
                 if (pendingMessages) {
-                    JOptionPane.showMessageDialog(this, "Es sind noch Nachrichten im beA-Postausgang - bitte manuell prüfen!", com.jdimension.jlawyer.client.utils.DesktopUtils.POPUP_TITLE_WARNING, JOptionPane.WARNING_MESSAGE);
+                    Object[] exitOptions = new Object[]{"Trotzdem beenden", "Abbrechen"};
+                    int response = JOptionPane.showOptionDialog(this, "Es sind noch Nachrichten im beA-Postausgang - bitte manuell prüfen!\nTrotzdem beenden?", com.jdimension.jlawyer.client.utils.DesktopUtils.POPUP_TITLE_WARNING, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, exitOptions, exitOptions[1]);
+                    if (response != 0) {
+                        log.info("user cancelled closing the app because of pending beA outbox messages");
+                        return;
+                    }
                 }
             }
         } catch (Exception ex) {

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/AddNoteFrame.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/AddNoteFrame.java
@@ -721,6 +721,7 @@ public class AddNoteFrame extends javax.swing.JFrame implements AssistantFlowAda
     private static final Logger log = Logger.getLogger(AddNoteFrame.class.getName());
     private ArchiveFileBean aFile = null;
     private boolean initializing = true;
+    private String initialNoteContent = "";
 
     private boolean isRecording = false;
     private long recordingStarted = -1;
@@ -788,6 +789,7 @@ public class AddNoteFrame extends javax.swing.JFrame implements AssistantFlowAda
                 + "  \n"
                 + "</p><p>&nbsp;</p><p>&nbsp;</p>";
         this.htmlNoteEditor.setText(html);
+        this.initialNoteContent = this.htmlNoteEditor.getText();
 
         ClientSettings settings = ClientSettings.getInstance();
 
@@ -857,6 +859,13 @@ public class AddNoteFrame extends javax.swing.JFrame implements AssistantFlowAda
         AudioUtils.populateMicrophoneDevices(this.cmbDevices);
 
         this.initializing = false;
+        this.setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
+        this.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent e) {
+                confirmClose();
+            }
+        });
     }
 
     public void setFocusToBody() {
@@ -1284,17 +1293,22 @@ public class AddNoteFrame extends javax.swing.JFrame implements AssistantFlowAda
         pack();
     }// </editor-fold>//GEN-END:initComponents
 
-    private void cmdCancelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdCancelActionPerformed
-        String currentContent = this.htmlNoteEditor.getText();
-        log.debug("AddNoteFrame: Cancel clicked, current editor content length: " + currentContent.length() + " chars");
-        if (currentContent.length() > 200) {
-            int response = JOptionPane.showConfirmDialog(this, "Notiz verwerfen und Dialog schliessen?", "Notiz verwerfen", JOptionPane.YES_NO_OPTION);
-            if (response == JOptionPane.NO_OPTION) {
+    private void confirmClose() {
+        if (!this.htmlNoteEditor.getText().equals(this.initialNoteContent)) {
+            int response = JOptionPane.showConfirmDialog(this, "Notiz speichern?", "Notiz schließen", JOptionPane.YES_NO_CANCEL_OPTION);
+            if (response == JOptionPane.YES_OPTION) {
+                this.cmdAddDocumentActionPerformed(null);
+                return;
+            } else if (response != JOptionPane.NO_OPTION) {
                 return;
             }
         }
         this.setVisible(false);
         this.dispose();
+    }
+
+    private void cmdCancelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdCancelActionPerformed
+        this.confirmClose();
     }//GEN-LAST:event_cmdCancelActionPerformed
 
     private void cmdAddDocumentActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmdAddDocumentActionPerformed

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/mail/SendEmailFrame.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/mail/SendEmailFrame.java
@@ -810,6 +810,9 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
     private boolean replyOrForward = false;
     private boolean initializing = false;
 
+    private String lastProgrammaticBody = "";
+    private String lastAppliedTemplateName = "";
+
     // can be set by code that constructs the SendEmailFrame to "inject" a recently created link to a Nextcloud share
     // will be made available as a placeholder
     private String cloudLink = null;
@@ -842,6 +845,7 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
         this.replyOrForward = replyOrForward;
         this.initialize();
         this.initializing = false;
+        this.lastProgrammaticBody = this.currentBodyText();
     }
 
     private void initialize() {
@@ -1505,6 +1509,12 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
         return null;
     }
 
+    private String currentBodyText() {
+        String textBody = this.tp != null ? this.tp.getText() : "";
+        String htmlBody = this.hp != null ? this.hp.getText() : "";
+        return StringUtils.nonEmpty(textBody) + "\n" + StringUtils.nonEmpty(htmlBody);
+    }
+
     public void setBody(String preSignature, String postSignature, String contentType) {
         this.setBody(preSignature, postSignature, contentType, true);
     }
@@ -1568,6 +1578,7 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
                 this.hp.setCaretPosition(0);
             }
         }
+        this.lastProgrammaticBody = this.currentBodyText();
     }
 
     @Override
@@ -3357,6 +3368,15 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
 
         String tplName = selected.toString();
         if (!"".equals(tplName)) {
+            if (!this.currentBodyText().trim().isEmpty() && !this.currentBodyText().equals(this.lastProgrammaticBody)) {
+                int overwriteResponse = JOptionPane.showConfirmDialog(this, "Der bisherige Nachrichtentext wird durch die Vorlage ersetzt - fortfahren?", "Vorlage anwenden", JOptionPane.YES_NO_OPTION);
+                if (overwriteResponse != JOptionPane.YES_OPTION) {
+                    ignoreTemplateSelectionEvent = true;
+                    this.cmbTemplates.setSelectedItem(this.lastAppliedTemplateName);
+                    ignoreTemplateSelectionEvent = false;
+                    return;
+                }
+            }
             try {
                 ClientSettings settings = ClientSettings.getInstance();
                 JLawyerServiceLocator locator = JLawyerServiceLocator.getInstance(settings.getLookupProperties());
@@ -3522,6 +3542,8 @@ public class SendEmailFrame extends javax.swing.JFrame implements SendCommunicat
                         }
                     }
                 }
+                this.lastAppliedTemplateName = tplName;
+                this.lastProgrammaticBody = this.currentBodyText();
 
             } catch (Exception ex) {
                 log.error("Error initiating template", ex);


### PR DESCRIPTION
Closes #3204
Closes #3201
Closes #2743

Drei Stellen, an denen Nutzereingaben bisher ohne Rückfrage verloren gehen konnten — je ein Commit pro Issue:

- **#3204 Notizen-Editor:** Beim Schließen (Fenster-X oder Abbrechen) mit ungespeicherten Änderungen erscheint "Notiz speichern?" (Ja/Nein/Abbrechen). Eine unveränderte Notiz schließt weiterhin ohne Rückfrage; die bisherige 200-Zeichen-Heuristik entfällt.
- **#3201 E-Mail-Editor:** Die Auswahl einer Vorlage fragt nach, bevor sie selbst getippten Text überschreibt. Reines Wechseln zwischen Vorlagen ohne eigene Eingaben bleibt rückfragefrei; bei "Nein" bleiben Text und Vorlagen-Auswahl erhalten.
- **#2743 beA-Ausgang:** Die Warnung beim Beenden ("noch Nachrichten im Postausgang") ist jetzt abbrechbar — "Trotzdem beenden" / "Abbrechen" (Standard), statt eines reinen OK-Hinweises, nach dem das Beenden immer fortfuhr.

Keine `.form`-Änderungen. Manuelle Verifikation in NetBeans erfolgt nachgelagert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
