### PR TITLE
Fünf kleine Bugfixes: Dokumentenliste und Ordner (#1181, #2894, #2742, #2431, #2540)

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/configuration/DocumentFolderTemplatesDialog.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/configuration/DocumentFolderTemplatesDialog.java
@@ -1105,7 +1105,9 @@ public class DocumentFolderTemplatesDialog extends javax.swing.JDialog {
 
     private MutableTreeNode buildTree(DocumentFolder df) {
         DefaultMutableTreeNode node = new DefaultMutableTreeNode(df);
-        for (DocumentFolder child : df.getChildren()) {
+        java.util.List<DocumentFolder> sortedChildren = new java.util.ArrayList<>(df.getChildren());
+        sortedChildren.sort(java.util.Comparator.comparing(DocumentFolder::getName, String.CASE_INSENSITIVE_ORDER));
+        for (DocumentFolder child : sortedChildren) {
             node.add(buildTree(child));
         }
         return node;

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -6190,6 +6190,7 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
 
             }
             this.updateFavoriteDocuments();
+            this.updateDocumentTagsOverview();
 
         } catch (Exception ioe) {
             log.error("Error removing document", ioe);

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/CaseFolderPanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/CaseFolderPanel.java
@@ -1953,9 +1953,13 @@ public class CaseFolderPanel extends javax.swing.JPanel implements EventConsumer
         }
 
         // document might have been dragged onto a different folder
+        // and may carry a fresh change date / size / version after re-upload
         for (ArchiveFileDocumentsBean db : this.documents) {
             if (db.getId().equals(doc.getId())) {
                 db.setFolder(doc.getFolder());
+                db.setChangeDate(doc.getChangeDate());
+                db.setSize(doc.getSize());
+                db.setVersion(doc.getVersion());
             }
         }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/FoldersListPanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/FoldersListPanel.java
@@ -1010,6 +1010,9 @@ public class FoldersListPanel extends javax.swing.JPanel {
 
     void folderUpdated(CaseFolder folder) {
         this.caseFolderPanel.updateDocumentsInFolder(folder);
+        // rebuild the "move to folder" menu so renamed folders show their new name,
+        // mirroring what folderAdded / folderRemoved already do
+        this.caseFolderPanel.setRootFolder(this.getRootFolder(), this.getUnselectedFolderIds());
         this.forceRelayout();
     }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/SortButton.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/SortButton.java
@@ -679,8 +679,8 @@ public class SortButton extends JButton {
     public static int SORT_ASC = 20;
     public static int SORT_DESC = 30;
     
-    private static final ImageIcon ICON_ASC=new javax.swing.ImageIcon(SortButton.class.getResource("/icons16/material/baseline_expand_less_white_48dp.png"));
-    private static final ImageIcon ICON_DESC=new javax.swing.ImageIcon(SortButton.class.getResource("/icons16/material/baseline_expand_more_white_48dp.png"));
+    private static final ImageIcon ICON_ASC=new javax.swing.ImageIcon(SortButton.class.getResource("/icons16/material/baseline_expand_more_white_48dp.png"));
+    private static final ImageIcon ICON_DESC=new javax.swing.ImageIcon(SortButton.class.getResource("/icons16/material/baseline_expand_less_white_48dp.png"));
     private ImageIcon ICON_NONE=new javax.swing.ImageIcon(SortButton.class.getResource("/icons16/material/empty_20_1px.png"));
 
     private int sortState = SORT_NONE;


### PR DESCRIPTION
Closes #1181
Closes #2894
Closes #2742
Closes #2431
Closes #2540

Fünf kleine, unabhängige Bugfixes rund um Dokumentenliste und Ordner — je ein Commit pro Issue:

- **#1181:** Der Sortierpfeil der Dokumentenliste zeigt jetzt in Richtung des höchsten/neuesten Werts (nur die Icon-Zuordnung getauscht; Sortierlogik und gespeicherte Sortierzustände unverändert).
- **#2894:** Nach dem Speichern eines Dokuments blieb der alte Zeitstempel beim nächsten Umsortieren/Ordnerwechsel erhalten, weil `updateDocument` nur den Ordner ins Backing-Model kopierte — jetzt werden auch Änderungsdatum/Größe/Version übernommen.
- **#2742:** Nach dem Umbenennen eines Ordners zeigt das Kontextmenü "in Ordner verschieben" sofort den neuen Namen (der Umbenennen-Pfad baut das Menü jetzt genauso neu auf wie Anlegen/Löschen).
- **#2431:** Einstellungen → Akten → Dokumentordner zeigt Unterordner jetzt alphabetisch (Anzeige-Sortierung wie in der Akten-Ansicht; besonders nach dem Duplizieren von Strukturen sichtbar).
- **#2540:** Der Etiketten-Tooltip zählte in den Papierkorb verschobene Dokumente weiter mit, bis die Akte neu geladen wurde — der fehlende Refresh nach dem Löschen ist ergänzt (die Server-Abfrage filtert bereits korrekt).

Keine `.form`-Änderungen, keine Server-Änderungen. Manuelle Verifikation in NetBeans erfolgt nachgelagert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
