### PR TITLE
Fix: Leerzeichen-Artefakt bei Platzhaltern am Absatzende (setPlaceHolders)

### DIFF
--- a/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/documents/LibreOfficeAccess.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/documents/LibreOfficeAccess.java
@@ -1548,6 +1548,21 @@ public class LibreOfficeAccess {
                         }
                     }
 
+                    // if the placeholder is the last content of a paragraph, replace it without
+                    // appending a space - the auto-appended space would otherwise survive as a
+                    // trailing space artifact at the end of the line
+                    String regExKeyEol = PLACEHOLDER_REGEX_OPEN + key.substring(2, key.length() - 2) + PLACEHOLDER_REGEX_CLOSE + "$";
+                    String eolValue = value == null ? "" : value;
+                    TextNavigation eolSearch = new TextNavigation(regExKeyEol, outputOdt);
+                    while (eolSearch.hasNext()) {
+                        try {
+                            TextSelection item = (TextSelection) eolSearch.nextSelection();
+                            item.replaceWith(eolValue);
+                        } catch (Throwable t) {
+                            log.error("Error replacing " + regExKeyEol + " with " + eolValue + " in " + fileInFileSystem, t);
+                        }
+                    }
+
                     String regExKey = PLACEHOLDER_REGEX_OPEN + key.substring(2, key.length() - 2) + PLACEHOLDER_REGEX_CLOSE;
                     if (value == null) {
                         value = "";
@@ -2100,6 +2115,24 @@ public class LibreOfficeAccess {
                         } catch (Throwable t) {
                             log.error("Error replacing " + regExKey + " with " + value + " in " + fileInFileSystem, t);
                         }
+                    }
+                }
+
+                // if the placeholder is the last content of a cell text, replace it without
+                // appending a space - the auto-appended space would otherwise survive as a
+                // trailing space artifact
+                String regExKeyEol = PLACEHOLDER_REGEX_OPEN + key.substring(2, key.length() - 2) + PLACEHOLDER_REGEX_CLOSE + "$";
+                String eolValue = (String) values.get(key);
+                if (eolValue == null) {
+                    eolValue = "";
+                }
+                TextNavigation eolSearch = new TextNavigation(regExKeyEol, outputOds);
+                while (eolSearch.hasNext()) {
+                    try {
+                        TextSelection item = (TextSelection) eolSearch.nextSelection();
+                        item.replaceWith(eolValue);
+                    } catch (Throwable t) {
+                        log.error("Error replacing " + regExKeyEol + " with " + eolValue + " in " + fileInFileSystem, t);
                     }
                 }
 


### PR DESCRIPTION
## Problem

`LibreOfficeAccess.setPlaceHolders` hängt an jeden ersetzten Platzhalter automatisch ein Leerzeichen an, außer der Platzhalter wird unmittelbar von einem Satzzeichen oder einem Leerzeichen gefolgt (die `trailingChars`-Behandlung). Für direkt aneinandergrenzende Platzhalter wie `{{MANDANT_VORNAME}}{{MANDANT_NAME}}` ist das praktisch — steht der Platzhalter aber **am Ende eines Absatzes**, folgt auf das angehängte Leerzeichen nichts mehr und es bleibt als Artefakt am Zeilenende im gerenderten Dokument stehen.

Typische betroffene Vorlagenzeilen (jede Zeile, die mit einem Platzhalter endet):

- `Az.: {{GEGNER_AKTE_ZEICHEN}}` → `Az.: 33.61.02/191327␣`
- `Düsseldorf, den {{KURZDATUM}}` → `Düsseldorf, den 21.07.2026␣`
- Betreff-/Adresszeilen, die auf `{{MANDANT_ORT}}`, `{{GEGNER_ORT}}` usw. enden

In der Vorlage lässt sich das nicht vermeiden: Mit einem literalen Leerzeichen nach dem Platzhalter behält der trailingChars-Durchlauf dieses Leerzeichen, ohne eines hängt der Catch-all-Durchlauf eines an — das Ergebnis ist in beiden Fällen identisch.

Eine frühere Fassung der trailingChars-Liste enthielt `"\n"` (als auskommentierte Zeile über den aktuellen Arrays noch sichtbar) — der Zeilenende-Fall war also offenbar schon einmal berücksichtigt und ist verloren gegangen.

## Fix

Vor dem Catch-all-Durchlauf läuft ein zusätzlicher `TextNavigation`-Durchlauf mit einem am Absatzende verankerten Muster (`{{KEY}}$`), der den Platzhalter durch den nackten Wert ersetzt — ohne angehängtes Leerzeichen. `TextNavigation` prüft das Muster zuerst gegen den aggregierten Textinhalt des Absatz-Elements, `$` verankert also am tatsächlichen Absatzende und nicht an inneren Span-Grenzen.

Umgesetzt in beiden Zweigen von `setPlaceHolders` (ODT-Textdokumente und ODS-Tabellen).

## Verhalten unverändert

- Aneinandergrenzende Platzhalter (`{{VORNAME}}{{NAME}}`) rendern weiterhin als zwei Wörter.
- Platzhalter mit folgendem Satzzeichen oder Leerzeichen bleiben unberührt (bestehender trailingChars-Durchlauf).
- `{{INGO_TEXT}}` und leere Werte verhalten sich wie bisher.
- Kommt ein Platzhalter zweimal im selben Absatz vor, behandelt der neue Durchlauf nur das Vorkommen am Absatzende — frühere Vorkommen behalten das automatische Leerzeichen.

## Verifiziert

Reproduziert mit einer Produktiv-Vorlage (Briefkopf-Vorlage, bei der Az.-Zeile, Datumszeile und Betreffzeile jeweils mit einem Platzhalter enden): Vor dem Fix endet jede dieser Zeilen mit genau einem angehängten Leerzeichen (in der rohen `content.xml` nachvollziehbar — das Leerzeichen sitzt innerhalb des ersetzten Spans), mit dem Zeilenende-Durchlauf ist derselbe Render sauber. Das Modul kompiliert mit `mvn -pl j-lawyer-server/j-lawyer-server-ejb -am compile`.
