### PR TITLE
fix: Preserve inline images in sent emails

### DIFF
--- a/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/services/EmailService.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/services/EmailService.java
@@ -2115,6 +2115,95 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
         throw new Exception("Attachment not found: " + attachmentId);
     }
 
+    static MimeMultipart buildMimeMultipart(String body, String contentType, List<MailAttachmentDTO> attachments) throws Exception {
+        String effectiveContentType = contentType != null && !contentType.trim().isEmpty()
+                ? contentType : "text/plain";
+        if (!effectiveContentType.toLowerCase().contains("charset")) {
+            effectiveContentType += "; charset=UTF-8";
+        }
+
+        MimeBodyPart bodyPart = new MimeBodyPart();
+        bodyPart.setContent(body != null ? body : "", effectiveContentType);
+
+        boolean htmlBody = effectiveContentType.toLowerCase().contains("text/html");
+        boolean hasInlineAttachments = false;
+        if (htmlBody && attachments != null) {
+            for (MailAttachmentDTO att : attachments) {
+                if (isInlineAttachment(att)) {
+                    hasInlineAttachments = true;
+                    break;
+                }
+            }
+        }
+
+        MimeMultipart bodyMultipart = new MimeMultipart(hasInlineAttachments ? "related" : "mixed");
+        bodyMultipart.addBodyPart(bodyPart);
+
+        if (hasInlineAttachments) {
+            for (MailAttachmentDTO att : attachments) {
+                if (isInlineAttachment(att)) {
+                    bodyMultipart.addBodyPart(createMimeAttachmentPart(att, true));
+                }
+            }
+        }
+
+        boolean hasRegularAttachments = false;
+        if (attachments != null) {
+            for (MailAttachmentDTO att : attachments) {
+                if (att != null && !(htmlBody && isInlineAttachment(att))) {
+                    hasRegularAttachments = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasRegularAttachments) {
+            return bodyMultipart;
+        }
+
+        MimeMultipart rootMultipart = bodyMultipart;
+        if (hasInlineAttachments) {
+            rootMultipart = new MimeMultipart("mixed");
+            MimeBodyPart relatedPart = new MimeBodyPart();
+            relatedPart.setContent(bodyMultipart);
+            rootMultipart.addBodyPart(relatedPart);
+        }
+
+        for (MailAttachmentDTO att : attachments) {
+            if (att != null && !(htmlBody && isInlineAttachment(att))) {
+                rootMultipart.addBodyPart(createMimeAttachmentPart(att, false));
+            }
+        }
+        return rootMultipart;
+    }
+
+    private static boolean isInlineAttachment(MailAttachmentDTO att) {
+        return att != null && att.isInline()
+                && att.getContentId() != null && !att.getContentId().trim().isEmpty();
+    }
+
+    private static MimeBodyPart createMimeAttachmentPart(MailAttachmentDTO att, boolean inline) throws Exception {
+        MimeBodyPart attachmentPart = new MimeBodyPart();
+        String attachmentContentType = att.getContentType() != null && !att.getContentType().trim().isEmpty()
+                ? att.getContentType() : "application/octet-stream";
+        DataSource dataSource = new ByteArrayDataSource(att.getContent(), attachmentContentType);
+        attachmentPart.setDataHandler(new DataHandler(dataSource));
+        if (att.getName() != null && !att.getName().isEmpty()) {
+            attachmentPart.setFileName(att.getName());
+        }
+        if (inline) {
+            String contentId = att.getContentId().trim();
+            if (contentId.startsWith("<") && contentId.endsWith(">") && contentId.length() > 2) {
+                contentId = contentId.substring(1, contentId.length() - 1);
+            }
+            attachmentPart.setDisposition(Part.INLINE);
+            attachmentPart.setContentID("<" + contentId + ">");
+        } else {
+            attachmentPart.setDisposition(Part.ATTACHMENT);
+        }
+        return attachmentPart;
+    }
+
     private void smtpSendMail(MailboxSetup ms, String to, String cc, String bcc, String subject, String body, String contentType, List<MailAttachmentDTO> attachments, String priority, boolean readReceipt, String inReplyTo, String references) throws Exception {
         Properties props = new Properties();
         String server = ms.getEmailOutServer();
@@ -2184,28 +2273,7 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
             msg.setHeader("Disposition-Notification-To", ms.getEmailAddress());
             msg.setHeader("Return-Receipt-To", ms.getEmailAddress());
         }
-        MimeMultipart multipart = new MimeMultipart();
-        MimeBodyPart bodyPart = new MimeBodyPart();
-        String ct = contentType != null ? contentType : "text/plain";
-        if (!ct.toLowerCase().contains("charset")) {
-            ct += "; charset=UTF-8";
-        }
-        bodyPart.setContent(body, ct);
-        multipart.addBodyPart(bodyPart);
-        if (attachments != null) {
-            for (MailAttachmentDTO att : attachments) {
-                MimeBodyPart attachPart = new MimeBodyPart();
-                DataSource ds = new ByteArrayDataSource(att.getContent(), att.getContentType());
-                attachPart.setDataHandler(new DataHandler(ds));
-                attachPart.setFileName(att.getName());
-                if (att.isInline() && att.getContentId() != null) {
-                    attachPart.setDisposition(Part.INLINE);
-                    attachPart.setContentID("<" + att.getContentId() + ">");
-                }
-                multipart.addBodyPart(attachPart);
-            }
-        }
-        msg.setContent(multipart);
+        msg.setContent(buildMimeMultipart(body, contentType, attachments));
         msg.saveChanges();
         Transport.send(msg);
 
@@ -3001,29 +3069,15 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
         }
 
         String ct = dto.getBodyContentType() != null ? dto.getBodyContentType() : "text/plain";
-        MimeMultipart multipart = new MimeMultipart();
-        MimeBodyPart bodyPart = new MimeBodyPart();
-        bodyPart.setContent(dto.getBody() != null ? dto.getBody() : "", ct + "; charset=UTF-8");
-        multipart.addBodyPart(bodyPart);
-
+        List<MailAttachmentDTO> loadedAttachments = new ArrayList<>();
         if (atts != null) {
             for (MailAttachmentDTO att : atts) {
                 if (att.getContent() != null) {
-                    MimeBodyPart attPart = new MimeBodyPart();
-                    javax.activation.DataSource ds = new javax.mail.util.ByteArrayDataSource(
-                            att.getContent(), att.getContentType() != null ? att.getContentType() : "application/octet-stream");
-                    attPart.setDataHandler(new javax.activation.DataHandler(ds));
-                    attPart.setFileName(att.getName());
-                    if (att.isInline() && att.getContentId() != null) {
-                        attPart.setDisposition(javax.mail.Part.INLINE);
-                        attPart.setContentID("<" + att.getContentId() + ">");
-                    }
-                    multipart.addBodyPart(attPart);
+                    loadedAttachments.add(att);
                 }
             }
         }
-
-        emlMsg.setContent(multipart);
+        emlMsg.setContent(buildMimeMultipart(dto.getBody(), ct, loadedAttachments));
         emlMsg.saveChanges();
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -3057,20 +3111,7 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
             msg.setSubject(subject, StandardCharsets.UTF_8.name());
             msg.setSentDate(new Date());
 
-            MimeMultipart multipart = new MimeMultipart();
-            MimeBodyPart bodyPart = new MimeBodyPart();
-            bodyPart.setContent(body != null ? body : "", (contentType != null ? contentType : "text/plain") + "; charset=UTF-8");
-            multipart.addBodyPart(bodyPart);
-            if (attachments != null) {
-                for (MailAttachmentDTO att : attachments) {
-                    MimeBodyPart attPart = new MimeBodyPart();
-                    javax.activation.DataSource ds = new javax.mail.util.ByteArrayDataSource(att.getContent(), att.getContentType() != null ? att.getContentType() : "application/octet-stream");
-                    attPart.setDataHandler(new javax.activation.DataHandler(ds));
-                    attPart.setFileName(att.getName());
-                    multipart.addBodyPart(attPart);
-                }
-            }
-            msg.setContent(multipart);
+            msg.setContent(buildMimeMultipart(body, contentType, attachments));
             msg.setFlag(Flags.Flag.SEEN, markAsRead);
             msg.saveChanges();
 
@@ -3112,6 +3153,12 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
                 a.put("name", att.getName());
                 a.put("contentType", att.getContentType());
                 a.put("contentBytes", java.util.Base64.getEncoder().encodeToString(att.getContent()));
+                if (att.isInline()) {
+                    a.put("isInline", true);
+                    if (att.getContentId() != null) {
+                        a.put("contentId", att.getContentId());
+                    }
+                }
                 atts.add(a);
             }
             message.put("attachments", atts);

--- a/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/services/EmailService.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/main/java/com/jdimension/jlawyer/services/EmailService.java
@@ -2136,7 +2136,8 @@ public class EmailService implements EmailServiceRemote, EmailServiceLocal {
             }
         }
 
-        MimeMultipart bodyMultipart = new MimeMultipart(hasInlineAttachments ? "related" : "mixed");
+        // RFC 2387 requires the type parameter on multipart/related, naming the media type of the root part
+        MimeMultipart bodyMultipart = new MimeMultipart(hasInlineAttachments ? "related; type=\"text/html\"" : "mixed");
         bodyMultipart.addBodyPart(bodyPart);
 
         if (hasInlineAttachments) {

--- a/j-lawyer-server/j-lawyer-server-ejb/src/test/java/com/jdimension/jlawyer/services/EmailMimeStructureTest.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/test/java/com/jdimension/jlawyer/services/EmailMimeStructureTest.java
@@ -41,6 +41,7 @@ public class EmailMimeStructureTest {
                 Collections.singletonList(inlineImage)));
 
         Assert.assertTrue(multipart.getContentType().startsWith("multipart/related"));
+        Assert.assertTrue(multipart.getContentType().contains("type=\"text/html\""));
         Assert.assertEquals(2, multipart.getCount());
         Assert.assertTrue(multipart.getBodyPart(0).getContentType().startsWith("text/html"));
 
@@ -68,6 +69,7 @@ public class EmailMimeStructureTest {
 
         MimeMultipart related = (MimeMultipart) multipart.getBodyPart(0).getContent();
         Assert.assertTrue(related.getContentType().startsWith("multipart/related"));
+        Assert.assertTrue(related.getContentType().contains("type=\"text/html\""));
         Assert.assertEquals(2, related.getCount());
 
         MimeBodyPart attachmentPart = (MimeBodyPart) multipart.getBodyPart(1);

--- a/j-lawyer-server/j-lawyer-server-ejb/src/test/java/com/jdimension/jlawyer/services/EmailMimeStructureTest.java
+++ b/j-lawyer-server/j-lawyer-server-ejb/src/test/java/com/jdimension/jlawyer/services/EmailMimeStructureTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) j-lawyer.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.jdimension.jlawyer.services;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import javax.mail.Part;
+import javax.mail.Session;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EmailMimeStructureTest {
+
+    @Test
+    public void createsRelatedMultipartForHtmlWithInlineImage() throws Exception {
+        MailAttachmentDTO inlineImage = createAttachment(
+                "logo.jpg", "image/jpeg", true, "signature-logo@jlawyer");
+
+        MimeMultipart multipart = saveMultipart(EmailService.buildMimeMultipart(
+                "<p>Text</p><img src=\"cid:signature-logo@jlawyer\">",
+                "text/html",
+                Collections.singletonList(inlineImage)));
+
+        Assert.assertTrue(multipart.getContentType().startsWith("multipart/related"));
+        Assert.assertEquals(2, multipart.getCount());
+        Assert.assertTrue(multipart.getBodyPart(0).getContentType().startsWith("text/html"));
+
+        MimeBodyPart imagePart = (MimeBodyPart) multipart.getBodyPart(1);
+        Assert.assertEquals(Part.INLINE, imagePart.getDisposition());
+        Assert.assertEquals("<signature-logo@jlawyer>", imagePart.getContentID());
+        Assert.assertEquals("logo.jpg", imagePart.getFileName());
+    }
+
+    @Test
+    public void nestsRelatedMultipartInsideMixedForRegularAttachments() throws Exception {
+        MailAttachmentDTO inlineImage = createAttachment(
+                "logo.jpg", "image/jpeg", true, "signature-logo@jlawyer");
+        MailAttachmentDTO regularAttachment = createAttachment(
+                "agreement.pdf", "application/pdf", false, null);
+
+        MimeMultipart multipart = saveMultipart(EmailService.buildMimeMultipart(
+                "<p>Text</p><img src=\"cid:signature-logo@jlawyer\">",
+                "text/html",
+                Arrays.asList(inlineImage, regularAttachment)));
+
+        Assert.assertTrue(multipart.getContentType().startsWith("multipart/mixed"));
+        Assert.assertEquals(2, multipart.getCount());
+        Assert.assertTrue(multipart.getBodyPart(0).getContent() instanceof MimeMultipart);
+
+        MimeMultipart related = (MimeMultipart) multipart.getBodyPart(0).getContent();
+        Assert.assertTrue(related.getContentType().startsWith("multipart/related"));
+        Assert.assertEquals(2, related.getCount());
+
+        MimeBodyPart attachmentPart = (MimeBodyPart) multipart.getBodyPart(1);
+        Assert.assertEquals(Part.ATTACHMENT, attachmentPart.getDisposition());
+        Assert.assertEquals("agreement.pdf", attachmentPart.getFileName());
+    }
+
+    private MimeMultipart saveMultipart(MimeMultipart multipart) throws Exception {
+        MimeMessage message = new MimeMessage(Session.getInstance(new Properties()));
+        message.setContent(multipart);
+        message.saveChanges();
+        return (MimeMultipart) message.getContent();
+    }
+
+    private MailAttachmentDTO createAttachment(String name, String contentType,
+            boolean inline, String contentId) {
+        MailAttachmentDTO attachment = new MailAttachmentDTO();
+        attachment.setName(name);
+        attachment.setContentType(contentType);
+        attachment.setInline(inline);
+        attachment.setContentId(contentId);
+        attachment.setContent("test-content".getBytes(StandardCharsets.UTF_8));
+        return attachment;
+    }
+}


### PR DESCRIPTION
## Summary

- build HTML messages with inline attachments as multipart/related
- nest the related body inside multipart/mixed when regular attachments are present
- preserve inline metadata for generated EML messages and Microsoft Graph folder appends

## Testing

- mvn -pl j-lawyer-server/j-lawyer-server-ejb -am -Dtest=EmailMimeStructureTest -Dsurefire.failIfNoSpecifiedTests=false test
- full reactor build with build-fast.sh
- verified inline rendering for the recipient and in the IMAP Sent folder

Fixes #3512