### PR TITLE
Vier Bugfixes: Dokumentenliste und Ordner (#2894, #2742, #2431, #2540) — ohne SortButton-Änderung

### DIFF
--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/configuration/DocumentFolderTemplatesDialog.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/configuration/DocumentFolderTemplatesDialog.java
@@ -1105,7 +1105,9 @@ public class DocumentFolderTemplatesDialog extends javax.swing.JDialog {
 
     private MutableTreeNode buildTree(DocumentFolder df) {
         DefaultMutableTreeNode node = new DefaultMutableTreeNode(df);
-        for (DocumentFolder child : df.getChildren()) {
+        java.util.List<DocumentFolder> sortedChildren = new java.util.ArrayList<>(df.getChildren());
+        sortedChildren.sort(java.util.Comparator.comparing(DocumentFolder::getName, String.CASE_INSENSITIVE_ORDER));
+        for (DocumentFolder child : sortedChildren) {
             node.add(buildTree(child));
         }
         return node;

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/client/editors/files/ArchiveFilePanel.java
@@ -6264,6 +6264,7 @@ public class ArchiveFilePanel extends javax.swing.JPanel implements ThemeableEdi
 
             }
             this.updateFavoriteDocuments();
+            this.updateDocumentTagsOverview();
 
         } catch (Exception ioe) {
             log.error("Error removing document", ioe);

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/CaseFolderPanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/CaseFolderPanel.java
@@ -1953,9 +1953,13 @@ public class CaseFolderPanel extends javax.swing.JPanel implements EventConsumer
         }
 
         // document might have been dragged onto a different folder
+        // and may carry a fresh change date / size / version after re-upload
         for (ArchiveFileDocumentsBean db : this.documents) {
             if (db.getId().equals(doc.getId())) {
                 db.setFolder(doc.getFolder());
+                db.setChangeDate(doc.getChangeDate());
+                db.setSize(doc.getSize());
+                db.setVersion(doc.getVersion());
             }
         }
 

--- a/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/FoldersListPanel.java
+++ b/j-lawyer-client/src/main/java/com/jdimension/jlawyer/ui/folders/FoldersListPanel.java
@@ -1010,6 +1010,9 @@ public class FoldersListPanel extends javax.swing.JPanel {
 
     void folderUpdated(CaseFolder folder) {
         this.caseFolderPanel.updateDocumentsInFolder(folder);
+        // rebuild the "move to folder" menu so renamed folders show their new name,
+        // mirroring what folderAdded / folderRemoved already do
+        this.caseFolderPanel.setRootFolder(this.getRootFolder(), this.getUnselectedFolderIds());
         this.forceRelayout();
     }
 


### PR DESCRIPTION
Übernimmt vier der fünf Bugfixes aus #3498 (Autor: @PBaumfalk, Autorenschaft der Commits erhalten), **ohne** den Sortierpfeil-Fix `#1181`.

Closes #2894
Closes #2742
Closes #2431
Closes #2540

## Enthalten

- **#2894** (`CaseFolderPanel`): Nach dem Speichern eines Dokuments blieb der alte Zeitstempel beim nächsten Umsortieren/Ordnerwechsel erhalten, weil `updateDocument` nur den Ordner ins Backing-Model kopierte — jetzt werden auch Änderungsdatum/Größe/Version übernommen.
- **#2742** (`FoldersListPanel`): Nach dem Umbenennen eines Ordners zeigt das Kontextmenü "in Ordner verschieben" sofort den neuen Namen; `folderUpdated` baut das Menü jetzt genauso neu auf wie `folderAdded`/`folderRemoved`.
- **#2431** (`DocumentFolderTemplatesDialog`): Einstellungen → Akten → Dokumentordner zeigt Unterordner alphabetisch.
- **#2540** (`ArchiveFilePanel`): Der Etiketten-Tooltip zählte in den Papierkorb verschobene Dokumente weiter mit; der fehlende Refresh nach dem Löschen ist ergänzt.

## Nicht enthalten

- **#1181** (`SortButton`): Der Tausch von `ICON_ASC`/`ICON_DESC` ist bewusst ausgelassen. `SortButton.java` ist gegenüber master unverändert.

## Hinweise

Keine `.form`-Änderungen, keine Server-Änderungen. Die vier Commits sind Cherry-Picks aus #3498 auf aktuelles master; nur `ArchiveFilePanel.java` benötigte einen Auto-Merge (master hatte die Datei seither geändert), die anderen drei Dateien waren in master unberührt.
