### PR TITLE
ci(web): build the Angular UI (-Pweb) in PR validation

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -66,6 +66,19 @@ jobs:
       - name: Verify REST API spec (swagger equivalence gate)
         run: mvn -B -pl j-lawyer-server/j-lawyer-io test
 
+      # Build the Angular web UI (j-lawyer-web) so the frontend is actually exercised in
+      # CI. The module sits behind the -Pweb profile, so the plain build above does not
+      # touch it. npm.install.args is overridden to drop --offline: the default offline
+      # install expects a seeded/vendored npm cache (SUPPLY-CHAIN.md; tasks 2.2/2.2b),
+      # which is not in place, so CI installs online from the registry instead. Still
+      # lockfile-pinned (npm ci) and scripts stay ignored (.npmrc + explicit flag). The
+      # frontend-maven-plugin provisions its own Node/npm, so nothing else is needed.
+      - name: Build web UI (Angular, -Pweb)
+        run: >
+          mvn -B -Pweb -pl j-lawyer-web -am
+          -Dnpm.install.args="ci --ignore-scripts"
+          -Dmaven.test.skip=true install
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         with:


### PR DESCRIPTION
The `j-lawyer-web` module sits behind the `-Pweb` profile, so the pipeline's plain `mvn clean install` never compiled the Angular frontend — a green build said nothing about the web UI. This adds a dedicated PR-validation step that builds it.

### Why online install (no seeding needed)
The Maven web build defaults to `npm ci --offline`, which expects a seeded/vendored npm cache (`SUPPLY-CHAIN.md`; tasks 2.2/2.2b) that is **not in place**. The step overrides `npm.install.args` to drop `--offline`, so CI installs online from the registry — consistent with CI already using the network (Maven deps, and the frontend-maven-plugin downloading Node). Still:
- **lockfile-pinned** (`npm ci` enforces `package-lock.json` ↔ `package.json`)
- **scripts ignored** (`.npmrc` + explicit `--ignore-scripts`)

### Out of scope
- Full **offline/air-gapped** build in CI — still needs the `vendor-npm/` vendoring (tasks 2.2 / 2.2b).
- npm cache for speed — deliberately omitted for a first, simple version.

Follows the Angular 19 → 21 upgrade (#3547 / #3557), which is what made the frontend build worth gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)